### PR TITLE
Extend GAMSPy example notebook to demonstrate using cuOpt solver options

### DIFF
--- a/GAMSPy_integration_example/trnsport_cuopt.ipynb
+++ b/GAMSPy_integration_example/trnsport_cuopt.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:15.883029Z",
@@ -36,7 +36,7 @@
        "CompletedProcess(args='unzip -o cuopt-link-release.zip -d /home/gamsuser/andre/.venv/lib/python3.12/site-packages/gamspy_base', returncode=0)"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:40.915536Z",
@@ -163,7 +163,7 @@
        "san-diego       600"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.084284Z",
@@ -243,7 +243,7 @@
        "topeka       275"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -258,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.087770Z",
@@ -340,7 +340,7 @@
        "          topeka         1.4"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -363,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.092111Z",
@@ -388,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 37,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.093948Z",
@@ -413,7 +413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 38,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.164784Z",
@@ -450,7 +450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 39,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.173454Z",
@@ -474,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 40,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.180411Z",
@@ -504,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 41,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.191227Z",
@@ -560,7 +560,7 @@
        "1  san-diego             "
       ]
      },
-     "execution_count": 39,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -571,7 +571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 42,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.194209Z",
@@ -633,7 +633,7 @@
        "2    topeka             "
       ]
      },
-     "execution_count": 40,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -655,7 +655,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 43,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.196997Z",
@@ -711,7 +711,7 @@
        "1  san-diego  600.0"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -729,7 +729,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 44,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.202335Z",
@@ -791,7 +791,7 @@
        "2    topeka  275.0"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -809,7 +809,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 45,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.207532Z",
@@ -848,7 +848,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 46,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.210541Z",
@@ -930,7 +930,7 @@
        "          topeka       0.126"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -942,7 +942,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 47,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.213745Z",
@@ -1029,7 +1029,7 @@
        "5  san-diego    topeka  0.126"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1050,7 +1050,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 48,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.219662Z",
@@ -1137,7 +1137,7 @@
        "5  san-diego    topeka    1.4"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1155,7 +1155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 49,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.225778Z",
@@ -1242,7 +1242,7 @@
        "5  san-diego    topeka  0.126"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1270,7 +1270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 50,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.230884Z",
@@ -1313,7 +1313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 51,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.233875Z",
@@ -1350,7 +1350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 52,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.237863Z",
@@ -1373,7 +1373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 53,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.241111Z",
@@ -1404,7 +1404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 54,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.244117Z",
@@ -1438,7 +1438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 55,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.246093Z",
@@ -1469,7 +1469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 56,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.248970Z",
@@ -1507,12 +1507,16 @@
     "\n",
     "**Note**: The following cell contains the two most important pieces to get a GAMSPy model being solved by NVIDIA cuOpt:\n",
     "1. Disable solver validation via `gp.set_options({\"SOLVER_VALIDATION\": 0})` as the solver is manually \"plugged into\" GAMSPy\n",
-    "2. Choose cuOpt as solver with `transport.solve(solver=\"cuopt\", ...)`"
+    "2. Choose cuOpt as solver with `transport.solve(solver=\"cuopt\", ...)`\n",
+    "\n",
+    "Furthermore it sets two cuOpt solver options:\n",
+    "1. The [LP solution method](https://docs.nvidia.com/cuopt/user-guide/latest/lp-milp-settings.html#method) to PDLP\n",
+    "2. The [crossover flag](https://docs.nvidia.com/cuopt/user-guide/latest/lp-milp-settings.html#crossover) to false"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 57,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.251912Z",
@@ -1526,58 +1530,67 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Job _KOUVa9lhTvG5uTjqvKL_Uw.gms Start 07/17/25 17:31:15 50.2.0 d60bb663 LEX-LEG x86 64bit/Linux\n",
+      "--- Job _rxnMrrkkTdSMAdg_gVb7vw.gms Start 07/29/25 15:17:04 50.2.0 d60bb663 LEX-LEG x86 64bit/Linux\n",
       "--- Applying:\n",
       "    /home/gamsuser/andre/.venv/lib/python3.12/site-packages/gamspy_base/gmsprmun.txt\n",
       "    /home/gamsuser/andre/.venv/lib/python3.12/site-packages/gamspy_base/gamsconfig.yaml\n",
       "--- GAMS Parameters defined\n",
       "    LP cuopt\n",
-      "    Input /tmp/tmpn3ks7sgm/_KOUVa9lhTvG5uTjqvKL_Uw.gms\n",
-      "    Output /tmp/tmpn3ks7sgm/_KOUVa9lhTvG5uTjqvKL_Uw.lst\n",
-      "    ScrDir /tmp/tmpn3ks7sgm/tmp_wk_zgjf/\n",
+      "    Input /tmp/tmpz9ur7fc2/_rxnMrrkkTdSMAdg_gVb7vw.gms\n",
+      "    Output /tmp/tmpz9ur7fc2/_rxnMrrkkTdSMAdg_gVb7vw.lst\n",
+      "    ScrDir /tmp/tmpz9ur7fc2/tmpl56e8q64/\n",
       "    SysDir /home/gamsuser/andre/.venv/lib/python3.12/site-packages/gamspy_base/\n",
       "    LogOption 3\n",
-      "    Trace /tmp/tmpn3ks7sgm/_KOUVa9lhTvG5uTjqvKL_Uw.txt\n",
+      "    Trace /tmp/tmpz9ur7fc2/_rxnMrrkkTdSMAdg_gVb7vw.txt\n",
       "    License /home/gamsuser/andre/.venv/lib/python3.12/site-packages/gamspy_base/gamslice.txt\n",
-      "    OptFile 0\n",
-      "    OptDir /tmp/tmpn3ks7sgm/\n",
+      "    OptFile 1\n",
+      "    OptDir /tmp/tmpz9ur7fc2/\n",
       "    LimRow 0\n",
       "    LimCol 0\n",
       "    TraceOpt 3\n",
-      "    GDX /tmp/tmpn3ks7sgm/_KOUVa9lhTvG5uTjqvKL_Uwout.gdx\n",
+      "    GDX /tmp/tmpz9ur7fc2/_rxnMrrkkTdSMAdg_gVb7vwout.gdx\n",
       "    SolPrint 0\n",
       "    PreviousWork 1\n",
       "    gdxSymbols newOrChanged\n",
       "System information: 12 physical cores and 62 Gb physical memory detected\n",
       "--- Starting compilation\n",
-      "--- _KOUVa9lhTvG5uTjqvKL_Uw.gms(71) 4 Mb\n",
+      "--- _rxnMrrkkTdSMAdg_gVb7vw.gms(71) 4 Mb\n",
       "--- Starting execution: elapsed 0:00:00.000\n",
       "--- Generating LP model transport\n",
-      "--- _KOUVa9lhTvG5uTjqvKL_Uw.gms(142) 4 Mb\n",
+      "--- _rxnMrrkkTdSMAdg_gVb7vw.gms(142) 4 Mb\n",
       "---   6 rows  7 columns  19 non-zeroes\n",
       "--- Range statistics (absolute non-zero finite values)\n",
       "--- RHS       [min, max] : [ 2.750E+02, 6.000E+02] - Zero values observed as well\n",
       "--- Bound     [min, max] : [        NA,        NA] - Zero values observed as well\n",
       "--- Matrix    [min, max] : [ 1.260E-01, 1.000E+00]\n",
-      "--- Executing CUOPT (Solvelink=2): elapsed 0:00:00.001\n",
-      "Setting parameter log_file to /tmp/tmpn3ks7sgm/tmp_wk_zgjf/cuopt.dat\n",
+      "--- Executing CUOPT (Solvelink=2): elapsed 0:00:00.000\n",
+      "Reading parameter(s) from \"/tmp/tmpz9ur7fc2/cuopt.opt\"\n",
+      ">>  method 1\n",
+      ">>  crossover 0\n",
+      "Finished reading from \"/tmp/tmpz9ur7fc2/cuopt.opt\"\n",
+      "Setting parameter method to 1\n",
+      "Setting parameter crossover to false\n",
+      "Setting parameter log_file to /tmp/tmpz9ur7fc2/tmpl56e8q64/cuopt.dat\n",
       "Solving a problem with 5 constraints 6 variables (0 integers) and 12 nonzeros\n",
       "Objective offset -0.000000 scaling_factor 1.000000\n",
-      "Running concurrent\n",
-      "\n",
-      "Dual simplex finished in 0.00 seconds\n",
       "   Iter    Primal Obj.      Dual Obj.    Gap        Primal Res.  Dual Res.   Time\n",
       "      0 +0.00000000e+00 +0.00000000e+00  0.00e+00   5.21e+02     0.00e+00   0.010s\n",
+      "      1 +0.00000000e+00 +1.54766674e+02  1.55e+02   5.21e+02     3.70e-02   0.013s\n",
+      "    120 +1.53675002e+02 +1.53675000e+02  2.40e-06   0.00e+00     0.00e+00   0.021s\n",
+      "LP Solver status:                Optimal\n",
+      "Primal objective:                +1.53675002e+02\n",
+      "Dual objective:                  +1.53675000e+02\n",
+      "Duality gap (abs/rel):           +2.40e-06 / +7.77e-09\n",
+      "Primal infeasibility (abs/rel):  +0.00e+00 / +0.00e+00\n",
+      "Dual infeasibility (abs/rel):    +0.00e+00 / +0.00e+00\n",
       "PDLP finished\n",
-      "Concurrent time:  0.012s\n",
-      "Solved with dual simplex\n",
-      "Status: Optimal   Objective: 1.53675000e+02  Iterations: 4  Time: 0.012s\n",
+      "Status: Optimal   Objective: 1.53675002e+02  Iterations: 120  Time: 0.021s\n",
       "--- Reading solution for model transport\n",
-      "--- Executing after solve: elapsed 0:00:00.174\n",
-      "--- _KOUVa9lhTvG5uTjqvKL_Uw.gms(201) 4 Mb\n",
-      "--- GDX File /tmp/tmpn3ks7sgm/_KOUVa9lhTvG5uTjqvKL_Uwout.gdx\n",
+      "--- Executing after solve: elapsed 0:00:00.184\n",
+      "--- _rxnMrrkkTdSMAdg_gVb7vw.gms(201) 4 Mb\n",
+      "--- GDX File /tmp/tmpz9ur7fc2/_rxnMrrkkTdSMAdg_gVb7vwout.gdx\n",
       "*** Status: Normal completion\n",
-      "--- Job _KOUVa9lhTvG5uTjqvKL_Uw.gms Stop 07/17/25 17:31:15 elapsed 0:00:00.174\n"
+      "--- Job _rxnMrrkkTdSMAdg_gVb7vw.gms Stop 07/29/25 15:17:04 elapsed 0:00:00.184\n"
      ]
     },
     {
@@ -1616,7 +1629,7 @@
        "      <th>0</th>\n",
        "      <td>Normal</td>\n",
        "      <td>OptimalGlobal</td>\n",
-       "      <td>153.675</td>\n",
+       "      <td>153.675002</td>\n",
        "      <td>6</td>\n",
        "      <td>7</td>\n",
        "      <td>LP</td>\n",
@@ -1628,14 +1641,14 @@
        "</div>"
       ],
       "text/plain": [
-       "  Solver Status   Model Status  Objective  Num of Equations  Num of Variables  \\\n",
-       "0        Normal  OptimalGlobal    153.675                 6                 7   \n",
+       "  Solver Status   Model Status   Objective  Num of Equations  \\\n",
+       "0        Normal  OptimalGlobal  153.675002                 6   \n",
        "\n",
-       "  Model Type Solver  Solver Time  \n",
-       "0         LP  CUOPT          0.0  "
+       "   Num of Variables Model Type Solver  Solver Time  \n",
+       "0                 7         LP  CUOPT          0.0  "
       ]
      },
-     "execution_count": 55,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1645,7 +1658,7 @@
     "import gamspy as gp\n",
     "\n",
     "gp.set_options({\"SOLVER_VALIDATION\": 0})\n",
-    "transport.solve(solver=\"cuopt\", output=sys.stdout)"
+    "transport.solve(solver=\"cuopt\", solver_options=dict(method=1, crossover=0), output=sys.stdout)"
    ]
   },
   {
@@ -1659,7 +1672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 58,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.454555Z",
@@ -1711,24 +1724,24 @@
        "    <tr>\n",
        "      <th rowspan=\"3\" valign=\"top\">seattle</th>\n",
        "      <th>new-york</th>\n",
-       "      <td>50.0</td>\n",
-       "      <td>0.0000</td>\n",
+       "      <td>26.674607</td>\n",
+       "      <td>6.551882e-10</td>\n",
        "      <td>0.0</td>\n",
        "      <td>inf</td>\n",
        "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>chicago</th>\n",
-       "      <td>300.0</td>\n",
-       "      <td>0.0000</td>\n",
+       "      <td>300.000007</td>\n",
+       "      <td>4.425912e-10</td>\n",
        "      <td>0.0</td>\n",
        "      <td>inf</td>\n",
        "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>topeka</th>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0180</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>3.600000e-02</td>\n",
        "      <td>0.0</td>\n",
        "      <td>inf</td>\n",
        "      <td>1.0</td>\n",
@@ -1736,24 +1749,24 @@
        "    <tr>\n",
        "      <th rowspan=\"3\" valign=\"top\">san-diego</th>\n",
        "      <th>new-york</th>\n",
-       "      <td>275.0</td>\n",
-       "      <td>0.0000</td>\n",
+       "      <td>298.325397</td>\n",
+       "      <td>6.551882e-10</td>\n",
        "      <td>0.0</td>\n",
        "      <td>inf</td>\n",
        "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>chicago</th>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0045</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>9.000000e-03</td>\n",
        "      <td>0.0</td>\n",
        "      <td>inf</td>\n",
        "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>topeka</th>\n",
-       "      <td>275.0</td>\n",
-       "      <td>0.0000</td>\n",
+       "      <td>275.000000</td>\n",
+       "      <td>1.093570e-14</td>\n",
        "      <td>0.0</td>\n",
        "      <td>inf</td>\n",
        "      <td>1.0</td>\n",
@@ -1763,17 +1776,17 @@
        "</div>"
       ],
       "text/plain": [
-       "                    level  marginal  lower  upper  scale\n",
-       "i         j                                             \n",
-       "seattle   new-york   50.0    0.0000    0.0    inf    1.0\n",
-       "          chicago   300.0    0.0000    0.0    inf    1.0\n",
-       "          topeka      0.0    0.0180    0.0    inf    1.0\n",
-       "san-diego new-york  275.0    0.0000    0.0    inf    1.0\n",
-       "          chicago     0.0    0.0045    0.0    inf    1.0\n",
-       "          topeka    275.0    0.0000    0.0    inf    1.0"
+       "                         level      marginal  lower  upper  scale\n",
+       "i         j                                                      \n",
+       "seattle   new-york   26.674607  6.551882e-10    0.0    inf    1.0\n",
+       "          chicago   300.000007  4.425912e-10    0.0    inf    1.0\n",
+       "          topeka      0.000000  3.600000e-02    0.0    inf    1.0\n",
+       "san-diego new-york  298.325397  6.551882e-10    0.0    inf    1.0\n",
+       "          chicago     0.000000  9.000000e-03    0.0    inf    1.0\n",
+       "          topeka    275.000000  1.093570e-14    0.0    inf    1.0"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1799,7 +1812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 59,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2025-07-17T10:21:41.459304Z",
@@ -1812,10 +1825,10 @@
     {
      "data": {
       "text/plain": [
-       "153.675"
+       "153.67500205075316"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
This very minor PR modifies the GAMSPy Jupyter example notebook to set two cuOpt [LP settings](https://docs.nvidia.com/cuopt/user-guide/latest/lp-milp-settings.html) in the GAMSPy `model.solve` invocation. It should just demonstrate how easy it is to customize the use of cuOpt from GAMSPy by setting some solver options.