### PR TITLE
Remove explicit versions from cuopt pip install in notebooks

### DIFF
--- a/GAMSPy_integration_example/trnsport_cuopt.ipynb
+++ b/GAMSPy_integration_example/trnsport_cuopt.ipynb
@@ -43,7 +43,7 @@
    ],
    "source": [
     "# remove -q to debug issues with pip installs\n",
-    "!pip install -q --extra-index-url=https://pypi.nvidia.com cuopt-cu12==25.5.* nvidia-cuda-runtime-cu12==12.8.* nvidia-nvjitlink-cu12\n",
+    "!pip install --upgrade -q --extra-index-url=https://pypi.nvidia.com cuopt-cu12 nvidia-cuda-runtime-cu12==12.8.* nvidia-nvjitlink-cu12\n",
     "!pip install -q gamspy\n",
     "import subprocess\n",
     "import sys\n",

--- a/PuLP_integration_example/Production_Planning_Example_Pulp.ipynb
+++ b/PuLP_integration_example/Production_Planning_Example_Pulp.ipynb
@@ -59,7 +59,7 @@
       "source": [
         "# # Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
         "\n",
-        "# !pip install --extra-index-url=https://pypi.nvidia.com cuopt-cu12==25.5.*"
+        "#!pip install --upgrade --extra-index-url=https://pypi.nvidia.com cuopt-cu12"
       ],
       "metadata": {
         "collapsed": true,

--- a/PuLP_integration_example/Simple_LP_pulp.ipynb
+++ b/PuLP_integration_example/Simple_LP_pulp.ipynb
@@ -60,7 +60,7 @@
       "source": [
         "# # Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
         "\n",
-        "# !pip install --extra-index-url=https://pypi.nvidia.com cuopt-cu12==25.5.*"
+        "#!pip install --upgrade --extra-index-url=https://pypi.nvidia.com cuopt-cu12"
       ],
       "metadata": {
         "id": "sb7vBllkojMN"

--- a/PuLP_integration_example/Simple_MIP_pulp.ipynb
+++ b/PuLP_integration_example/Simple_MIP_pulp.ipynb
@@ -49,7 +49,7 @@
       "source": [
         "# # Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
         "\n",
-        "# !pip install --extra-index-url=https://pypi.nvidia.com cuopt-cu12==25.5.*"
+        "#!pip install --upgrade --extra-index-url=https://pypi.nvidia.com cuopt-cu12"
       ]
     },
     {

--- a/PuLP_integration_example/Sudoku_pulp.ipynb
+++ b/PuLP_integration_example/Sudoku_pulp.ipynb
@@ -50,7 +50,7 @@
       "source": [
         "# # Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
         "\n",
-        "# !pip install --extra-index-url=https://pypi.nvidia.com cuopt-cu12==25.5.*"
+        "#!pip install --upgrade --extra-index-url=https://pypi.nvidia.com cuopt-cu12"
       ]
     },
     {

--- a/cuFOLIO_portfolio_optimization/CVaR/01_optimization_with_cufolio.ipynb
+++ b/cuFOLIO_portfolio_optimization/CVaR/01_optimization_with_cufolio.ipynb
@@ -40,10 +40,10 @@
     "# If dependencies are already installed, you can comment out or skip this cell.\n",
     "\n",
     "# Install cuOpt (if not already installed)\n",
-    "# !pip install --user --extra-index-url https://pypi.nvidia.com -q cuopt-cu12==25.5.*\n",
+    "#!pip install --upgrade --user --extra-index-url https://pypi.nvidia.com -q cuopt-cu12\n",
     "\n",
     "# Install other dependencies (if not already installed)\n",
-    "# !pip install --user --extra-index-url https://pypi.nvidia.com -q \"numpy>=1.24.4\" \"pandas>=2.2.1\" \"cvxpy>=1.6.5\" \"scipy==1.15.2\" \"scikit-learn==1.6.1\" \"msgpack>=1.1.0\" \"cuml-cu12==25.4.*\" \"seaborn>=0.13.2\" bin/cufolio-25.8-py3-none-any.whl"
+    "#!pip install --user --extra-index-url https://pypi.nvidia.com -q \"numpy>=1.24.4\" \"pandas>=2.2.1\" \"cvxpy>=1.6.5\" \"scipy==1.15.2\" \"scikit-learn==1.6.1\" \"msgpack>=1.1.0\" \"cuml-cu12==25.4.*\" \"seaborn>=0.13.2\" bin/cufolio-25.8-py3-none-any.whl"
    ]
   },
   {

--- a/intra-factory_transport/intra-factory_transport.ipynb
+++ b/intra-factory_transport/intra-factory_transport.ipynb
@@ -75,11 +75,8 @@
     "\n",
     "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
     "\n",
-    "# This would be incase underlying system is cuda-10.X \n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-cu11==25.5.* \n",
     "\n",
-    "# This would be incase underlying system is cuda-12.x\n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-cu12==25.5."
+    "#!pip install --upgrade --extra-index-url https://pypi.nvidia.com --user cuopt-cu12"
    ]
   },
   {

--- a/last_mile_delivery/cvrp_daily_deliveries.ipynb
+++ b/last_mile_delivery/cvrp_daily_deliveries.ipynb
@@ -87,11 +87,8 @@
     "\n",
     "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
     "\n",
-    "# This would be incase underlying system is cuda-11.X \n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-cu11==25.5.* \n",
     "\n",
-    "# This would be incase underlying system is cuda-12.x\n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-cu12==25.5.*"
+    "#!pip install --upgrade --extra-index-url https://pypi.nvidia.com --user cuopt-cu12"
    ]
   },
   {

--- a/last_mile_delivery/cvrptw_benchmark_gehring_homberger.ipynb
+++ b/last_mile_delivery/cvrptw_benchmark_gehring_homberger.ipynb
@@ -62,11 +62,8 @@
     "\n",
     "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
     "\n",
-    "# This would be incase underlying system is cuda-10.X \n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-cu11==25.5.* \n",
     "\n",
-    "# This would be incase underlying system is cuda-12.x\n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-cu12==25.5.*"
+    "#!pip install --upgrade --extra-index-url https://pypi.nvidia.com --user cuopt-cu12"
    ]
   },
   {

--- a/last_mile_delivery/cvrptw_service_team_routing.ipynb
+++ b/last_mile_delivery/cvrptw_service_team_routing.ipynb
@@ -91,11 +91,8 @@
     "\n",
     "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
     "\n",
-    "# This would be incase underlying system is cuda-10.X \n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-cu11==25.5.* \n",
     "\n",
-    "# This would be incase underlying system is cuda-12.x\n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-cu12==25.5.*"
+    "#!pip install --upgrade --extra-index-url https://pypi.nvidia.com --user cuopt-cu12"
    ]
   },
   {

--- a/routing_optimization_over_server/cvrptw_benchmark_gehring_homberger.ipynb
+++ b/routing_optimization_over_server/cvrptw_benchmark_gehring_homberger.ipynb
@@ -62,7 +62,7 @@
     "\n",
     "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
     "\n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12==25.5.* cuopt-sh-client==25.5.*"
+    "#!pip install --upgrade --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12 cuopt-sh-client"
    ]
   },
   {

--- a/routing_optimization_over_server/cvrptw_service_team_routing.ipynb
+++ b/routing_optimization_over_server/cvrptw_service_team_routing.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
     "\n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12==25.5.* cuopt-sh-client==25.5.*"
+    "#!pip install --upgrade --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12 cuopt-sh-client"
    ]
   },
   {

--- a/sample_lp_sever_notebooks/linear-programming-with-datamodel.ipynb
+++ b/sample_lp_sever_notebooks/linear-programming-with-datamodel.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
     "\n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12==25.8.* cuopt-sh-client==25.8.*"
+    "#!pip install --upgrade --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12 cuopt-sh-client"
    ]
   },
   {

--- a/sample_lp_sever_notebooks/linear-programming.ipynb
+++ b/sample_lp_sever_notebooks/linear-programming.ipynb
@@ -69,7 +69,7 @@
     "\n",
     "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
     "\n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12==25.8.* cuopt-sh-client==25.8.*"
+    "#!pip install --upgrade --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12 cuopt-sh-client"
    ]
   },
   {

--- a/sample_lp_sever_notebooks/mixed-integer-linear-programming-with-datamodel.ipynb
+++ b/sample_lp_sever_notebooks/mixed-integer-linear-programming-with-datamodel.ipynb
@@ -70,7 +70,7 @@
     "\n",
     "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
     "\n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12==25.8.* cuopt-sh-client==25.8.*"
+    "#!pip install --upgrade --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12 cuopt-sh-client"
    ]
   },
   {

--- a/sample_lp_sever_notebooks/mixed-integer-linear-programming.ipynb
+++ b/sample_lp_sever_notebooks/mixed-integer-linear-programming.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
     "\n",
-    "# !pip install --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12==25.8.* cuopt-sh-client==25.8.*"
+    "#!pip install --upgrade --extra-index-url https://pypi.nvidia.com --user cuopt-server-cu12 cuopt-sh-client"
    ]
   },
   {


### PR DESCRIPTION
Use the --upgrade flag with no version number.
Also remove the initial space in a commented out pip command so that a user just needs to delete the pound sign to enable the command