### PR TITLE
Fix cuopt-agent skills symlink in production image

### DIFF
--- a/cuopt-agent/cuopt_agent/docker/Dockerfile
+++ b/cuopt-agent/cuopt_agent/docker/Dockerfile
@@ -31,6 +31,7 @@ ENV PATH="/app/cuopt_agent/.venv/bin:$PATH"
 COPY cuopt_agent/configs /app/cuopt_agent/configs
 COPY cuopt_agent/data    /app/cuopt_agent/data
 COPY skills              /app/skills
+COPY external/cuopt/skills /app/external/cuopt/skills
 COPY AGENTS.md           /app/AGENTS.md
 
 # CWD must be cuopt_agent/ so config relative paths resolve correctly:


### PR DESCRIPTION
## Summary

- copy `external/cuopt/skills` into the production image
- fix the dangling `skills/cuopt -> ../external/cuopt/skills` symlink
- remove the need for a runtime volume-mount workaround to access upstream cuOpt skills

## Issue

Closes #122

## Observed Issue

After building the production image, the image contains:

```text
/app/skills/cuopt -> ../external/cuopt/skills