### PR TITLE
Add LP sensitivity analysis (duals + reduced costs) to the diet example

### DIFF
--- a/diet_optimization/README.md
+++ b/diet_optimization/README.md
@@ -13,9 +13,9 @@ The diet optimization notebook solves a linear programming problem where:
 - The foods have different prices and nutritional values.
 
 The notebook also demonstrates **sensitivity analysis** on the solved LP: reading constraint
-**shadow prices** (`DualValue`) and variable **reduced costs** (`ReducedCost`) to see which
+**dual values** (`DualValue`) and variable **reduced costs** (`ReducedCost`) to see which
 nutritional requirements drive the cost and how far each unused food is from entering the diet,
-then adding a constraint and reading *its* shadow price (the marginal cost of the cap).
+then adding a constraint and reading *its* dual value (the marginal cost of the cap).
 
 
 ### 2. Diet Optimization (MILP)

--- a/diet_optimization/README.md
+++ b/diet_optimization/README.md
@@ -14,8 +14,7 @@ The diet optimization notebook solves a linear programming problem where:
 
 The notebook also demonstrates **sensitivity analysis** on the solved LP: reading constraint
 **dual values** (`DualValue`) and variable **reduced costs** (`ReducedCost`) to see which
-nutritional requirements drive the cost and how far each unused food is from entering the diet,
-then adding a constraint and reading *its* dual value (the marginal cost of the cap).
+nutritional requirements drive the cost and how far each unused food is from entering the diet.
 
 
 ### 2. Diet Optimization (MILP)

--- a/diet_optimization/README.md
+++ b/diet_optimization/README.md
@@ -12,6 +12,11 @@ The diet optimization notebook solves a linear programming problem where:
 - The diet is a mix of different foods.
 - The foods have different prices and nutritional values.
 
+The notebook also demonstrates **sensitivity analysis** on the solved LP: reading constraint
+**shadow prices** (`DualValue`) and variable **reduced costs** (`ReducedCost`) to see which
+nutritional requirements drive the cost and how far each unused food is from entering the diet,
+then adding a constraint and reading *its* shadow price (the marginal cost of the cap).
+
 
 ### 2. Diet Optimization (MILP)
 

--- a/diet_optimization/README.md
+++ b/diet_optimization/README.md
@@ -14,7 +14,8 @@ The diet optimization notebook solves a linear programming problem where:
 
 The notebook also demonstrates **sensitivity analysis** on the solved LP: reading constraint
 **dual values** (`DualValue`) and variable **reduced costs** (`ReducedCost`) to see which
-nutritional requirements drive the cost and how far each unused food is from entering the diet.
+nutritional requirements drive the cost at the margin and roughly how far each unused food is
+from entering the diet (local rates — see the notebook's degeneracy and units caveats).
 
 
 ### 2. Diet Optimization (MILP)

--- a/diet_optimization/diet_optimization_lp.ipynb
+++ b/diet_optimization/diet_optimization_lp.ipynb
@@ -384,11 +384,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Sensitivity Analysis: Shadow Prices and Reduced Costs\n",
+    "## Sensitivity Analysis: Duals and Reduced Costs\n",
     "\n",
     "Because every variable here is continuous, this is a linear program, and cuOpt returns dual information at the optimum — the economic \"why\" behind the plan:\n",
     "\n",
-    "- **Shadow price (constraint dual)** — how much the minimum cost changes per unit change in a constraint's bound. A *binding* constraint has a nonzero shadow price; a slack one is approximately zero.\n",
+    "- **Constraint dual** — the sensitivity of the optimal cost to a constraint's bound: how much the minimum cost changes per unit change in that bound (traditionally called the *shadow price*). A *binding* constraint has a nonzero dual; a slack one is approximately zero.\n",
     "- **Reduced cost (variable dual)** — for a food left out of the diet (amount 0), how much its per-serving price would have to fall before buying it could lower total cost."
    ]
   },
@@ -400,7 +400,7 @@
    "source": [
     "# Sensitivity analysis — read the LP duals at the optimum\n",
     "if problem.Status.name == \"Optimal\":\n",
-    "    print(\"Shadow prices (constraint duals) — change in cost per unit change in the bound:\")\n",
+    "    print(\"Constraint duals — change in cost per unit change in the bound:\")\n",
     "    for c in problem.getConstraints():\n",
     "        print(f\"  {c.ConstraintName:14s} dual={c.DualValue:+.4f}  slack={c.Slack:.4f}\")\n",
     "\n",
@@ -417,7 +417,7 @@
    "source": [
     "## Adding Additional Constraints\n",
     "\n",
-    "Now let's add a constraint to the existing model and read its **shadow price**. We'll cap **hamburger + hot dog at 0.4 servings** combined — say, a red-meat preference — and re-solve."
+    "Now let's add a constraint to the existing model and read its **dual** — the sensitivity of cost to that constraint. We'll cap **hamburger + hot dog at 0.4 servings** combined — say, a red-meat preference — and re-solve."
    ]
   },
   {
@@ -454,9 +454,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### The Shadow Price of the Meat Cap\n",
+    "### The Dual of the Meat Cap\n",
     "\n",
-    "Capping hamburger and hot dog tightens the model and nudges the cost up. The cap's **dual** gives the marginal price of that limit directly — how much total cost changes per additional combined serving you allow — without re-solving at every level."
+    "Capping hamburger and hot dog tightens the model and nudges the cost up. The cap's **dual** gives the marginal cost of that limit directly — how much total cost changes per additional combined serving you allow — without re-solving at every level."
    ]
   },
   {
@@ -467,9 +467,9 @@
    "source": [
     "# Marginal cost of the meat cap, read straight off its dual\n",
     "if problem.Status.name == \"Optimal\":\n",
-    "    print(f\"limit_meat shadow price: {meat_constraint.DualValue:+.4f}  \"\n",
+    "    print(f\"limit_meat dual: {meat_constraint.DualValue:+.4f}  \"\n",
     "          f\"(cost change per +1 combined serving of hamburger/hot dog allowed)\")\n",
-    "    print(f\"slack on the cap:        {meat_constraint.Slack:.4f}   (0 means the cap is binding)\")"
+    "    print(f\"slack on the cap: {meat_constraint.Slack:.4f}   (0 means the cap is binding)\")"
    ]
   },
   {

--- a/diet_optimization/diet_optimization_lp.ipynb
+++ b/diet_optimization/diet_optimization_lp.ipynb
@@ -384,6 +384,37 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Sensitivity Analysis: Shadow Prices and Reduced Costs\n",
+    "\n",
+    "Because every variable here is continuous, this is a linear program, and cuOpt returns dual information at the optimum — the economic \"why\" behind the plan:\n",
+    "\n",
+    "- **Shadow price (constraint dual)** — how much the minimum cost changes per unit change in a constraint's bound. A *binding* nutrient floor has a nonzero shadow price; a slack constraint is approximately zero.\n",
+    "- **Reduced cost (variable dual)** — for a food left out of the diet (amount 0), how much its per-serving price would have to fall before buying it could lower total cost."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sensitivity analysis — read the LP duals at the optimum\n",
+    "if problem.Status.name == \"Optimal\":\n",
+    "    print(\"Shadow prices (constraint duals) — change in cost per unit change in the bound:\")\n",
+    "    for c in problem.getConstraints():\n",
+    "        print(f\"  {c.ConstraintName:14s} dual={c.DualValue:+.4f}  slack={c.Slack:.4f}\")\n",
+    "\n",
+    "    print(\"\\nReduced costs (variable duals) — for foods at 0, price drop needed to enter the diet:\")\n",
+    "    for v in problem.getVariables():\n",
+    "        print(f\"  {v.VariableName:12s} amount={v.getValue():7.3f}  reduced_cost={v.ReducedCost:+.4f}\")\n",
+    "else:\n",
+    "    print(f\"No duals available — solver status is {problem.Status.name}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Adding Additional Constraints\n",
     "\n",
     "Now let's demonstrate how to add additional constraints to the existing model. We'll add a constraint to limit dairy servings to at most 6.\n"
@@ -417,6 +448,28 @@
     "print(f\"\\nSolve completed in {solve_time:.3f} seconds\")\n",
     "print(f\"Solver status: {problem.Status.name}\")\n",
     "print(f\"Objective value: ${problem.ObjValue:.2f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The Shadow Price of the Dairy Cap\n",
+    "\n",
+    "We just capped dairy at 6 servings, and the cost rose. The cap's **dual** gives the marginal price of that limit directly — the change in total cost per additional serving of dairy allowed — without re-solving at every level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Marginal cost of the dairy cap, read straight off its dual\n",
+    "if problem.Status.name == \"Optimal\":\n",
+    "    print(f\"limit_dairy shadow price: {dairy_constraint.DualValue:+.4f}  \"\n",
+    "          f\"(cost change per +1 serving of dairy allowed)\")\n",
+    "    print(f\"slack on the cap:         {dairy_constraint.Slack:.4f}   (0 means the cap is binding)\")"
    ]
   },
   {

--- a/diet_optimization/diet_optimization_lp.ipynb
+++ b/diet_optimization/diet_optimization_lp.ipynb
@@ -388,7 +388,7 @@
     "\n",
     "Because every variable here is continuous, this is a linear program, and cuOpt returns dual information at the optimum — the economic \"why\" behind the plan:\n",
     "\n",
-    "- **Constraint dual** — the sensitivity of the optimal cost to a constraint's bound: how much the minimum cost changes per unit change in that bound (traditionally called the *shadow price*). A *binding* constraint has a nonzero dual; a slack one is approximately zero.\n",
+    "- **Constraint dual** — the sensitivity of the optimal cost to a constraint's bound: how much the minimum cost changes per unit change in that bound. A *binding* constraint has a nonzero dual; a slack one is approximately zero.\n",
     "- **Reduced cost (variable dual)** — for a food left out of the diet (amount 0), how much its per-serving price would have to fall before buying it could lower total cost."
    ]
   },

--- a/diet_optimization/diet_optimization_lp.ipynb
+++ b/diet_optimization/diet_optimization_lp.ipynb
@@ -13,7 +13,7 @@
     "We need to select quantities of different foods to:\n",
     "- Meet minimum and maximum nutritional requirements\n",
     "- Minimize total cost\n",
-    "- Satisfy additional constraints (like limiting red-meat servings)\n",
+    "- Satisfy additional constraints (like limiting dairy servings)\n",
     "\n",
     "The nutrition guidelines are based on USDA Dietary Guidelines for Americans, 2005.\n"
    ]
@@ -389,7 +389,9 @@
     "Because every variable here is continuous, this is a linear program, and cuOpt returns dual information at the optimum — the economic \"why\" behind the plan:\n",
     "\n",
     "- **Constraint dual** — the sensitivity of the optimal cost to a constraint's bound: how much the minimum cost changes per unit change in that bound. A *binding* constraint has a nonzero dual; a slack one is approximately zero.\n",
-    "- **Reduced cost (variable dual)** — for a food left out of the diet (amount 0), how much its per-serving price would have to fall before buying it could lower total cost."
+    "- **Reduced cost (variable dual)** — for a food left out of the diet (amount 0), how much its per-serving price would have to fall before buying it could lower total cost.\n",
+    "\n",
+    "Together they show where cost is most sensitive to change: relaxing the binding constraint with the largest dual lowers cost the most per unit, and the unused food with the smallest reduced cost is the first that would enter the diet if its price fell."
    ]
   },
   {
@@ -415,86 +417,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Adding Additional Constraints\n",
-    "\n",
-    "Now let's add a constraint to the existing model and read its **dual** — the sensitivity of cost to that constraint. We'll cap **hamburger + hot dog at 0.4 servings** combined — say, a red-meat preference — and re-solve."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Limit combined hamburger + hot dog servings (a red-meat preference)\n",
-    "meat_expr = buy_vars[\"hamburger\"] + buy_vars[\"hot dog\"]\n",
-    "meat_constraint = problem.addConstraint(meat_expr <= 0.4, name=\"limit_meat\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Solve the problem again with the new constraint\n",
-    "print(\"\\nSolving with the meat constraint...\")\n",
-    "print(f\"Problem now has {problem.NumVariables} variables and {problem.NumConstraints} constraints\")\n",
-    "\n",
-    "start_time = time.time()\n",
-    "problem.solve(settings)\n",
-    "solve_time = time.time() - start_time\n",
-    "\n",
-    "print(f\"\\nSolve completed in {solve_time:.3f} seconds\")\n",
-    "print(f\"Solver status: {problem.Status.name}\")\n",
-    "print(f\"Objective value: ${problem.ObjValue:.2f}\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### The Dual of the Meat Cap\n",
-    "\n",
-    "Capping hamburger and hot dog tightens the model and nudges the cost up. The cap's **dual** gives the marginal cost of that limit directly — how much total cost changes per additional combined serving you allow — without re-solving at every level."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Marginal cost of the meat cap, read straight off its dual\n",
-    "if problem.Status.name == \"Optimal\":\n",
-    "    print(f\"limit_meat dual: {meat_constraint.DualValue:+.4f}  \"\n",
-    "          f\"(cost change per +1 combined serving of hamburger/hot dog allowed)\")\n",
-    "    print(f\"slack on the cap: {meat_constraint.Slack:.4f}   (0 means the cap is binding)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Solution Comparison\n",
-    "\n",
-    "Let's compare the solutions before and after adding the meat cap to see the impact."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Display the new solution\n",
-    "print_solution()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Conclusion\n",
     "\n",
     "This notebook demonstrated how to:\n",
@@ -504,8 +426,7 @@
     "3. **Define an objective function** to minimize total cost\n",
     "4. **Add nutritional constraints** with both lower and upper bounds\n",
     "5. **Solve the optimization problem** using cuOpt's high-performance solver\n",
-    "6. **Add additional constraints** to the existing model\n",
-    "7. **Analyze and compare solutions** before and after constraint modifications\n",
+    "6. **Read dual values and reduced costs** to quantify how sensitive the optimal cost is to each binding constraint\n",
     "\n",
     "The cuOpt Python API provides a clean, intuitive interface for building and solving optimization problems, making it easy to model complex real-world scenarios like diet optimization.\n",
     "\n",

--- a/diet_optimization/diet_optimization_lp.ipynb
+++ b/diet_optimization/diet_optimization_lp.ipynb
@@ -384,14 +384,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Sensitivity Analysis: Duals and Reduced Costs\n",
+    "## Sensitivity Analysis: Dual Values and Reduced Costs\n",
     "\n",
-    "Because every variable here is continuous, this is a linear program, and cuOpt returns dual information at the optimum — the economic \"why\" behind the plan:\n",
+    "Every variable here is continuous, so cuOpt returns dual information at the optimum — the economic read behind the plan:\n",
     "\n",
-    "- **Constraint dual** — the sensitivity of the optimal cost to a constraint's bound: how much the minimum cost changes per unit change in that bound. A *binding* constraint has a nonzero dual; a slack one is approximately zero.\n",
-    "- **Reduced cost (variable dual)** — for a food left out of the diet (amount 0), how much its per-serving price would have to fall before buying it could lower total cost.\n",
-    "\n",
-    "Together they show where cost is most sensitive to change: relaxing the binding constraint with the largest dual lowers cost the most per unit, and the unused food with the smallest reduced cost is the first that would enter the diet if its price fell."
+    "- The binding nutrition limits carry nonzero **dual values** — the marginal cost of each: how much total cost moves per unit you tighten or relax that limit. The largest points to where renegotiating the requirement pays off most.\n",
+    "- Each food left out of the diet carries a **reduced cost** — how far its per-serving price must fall before buying it would lower total cost. The smallest is the first that would enter if prices shifted."
    ]
   },
   {

--- a/diet_optimization/diet_optimization_lp.ipynb
+++ b/diet_optimization/diet_optimization_lp.ipynb
@@ -388,8 +388,10 @@
     "\n",
     "Every variable here is continuous, so cuOpt returns dual information at the optimum — the economic read behind the plan:\n",
     "\n",
-    "- The binding nutrition limits carry nonzero **dual values** — the marginal cost of each: how much total cost moves per unit you tighten or relax that limit. The largest points to where renegotiating the requirement pays off most.\n",
-    "- Each food left out of the diet carries a **reduced cost** — how far its per-serving price must fall before buying it would lower total cost. The smallest is the first that would enter if prices shifted."
+    "- Each nutrition limit carries a **dual value** — at a non-degenerate optimum, how much total cost moves per unit you tighten or relax that limit. The implication runs one way: a limit with slack prices to ~0, while a binding limit (slack ≈ 0) *can* carry a nonzero dual but need not (a binding limit with a zero dual is a form of degeneracy). And a dual is $ per *that constraint's own unit* — per kcal for calories, per mg for sodium — so raw magnitudes aren't comparable across limits; to find where renegotiating pays off most, compare the value of, say, a 1% relaxation of each limit rather than ranking raw duals.\n",
+    "- A food left at 0 carries a **reduced cost** — roughly how far its per-serving price must fall before it *could* enter the diet without raising total cost. Reduced costs are per serving and serving sizes are arbitrary, so compare each as a fraction of the food's own price (\"needs a 5% price cut\" vs. \"a 40% one\") rather than sorting raw values.\n",
+    "\n",
+    "Two caveats keep the read honest: under degeneracy a dual is a local, one-sided rate — confirm any rate you quote with a one-unit re-solve — and cuOpt's default first-order (PDLP) path can return duals without a simplex basis, accurate only to the convergence tolerance, so tiny near-zero values are noise, not signal."
    ]
   },
   {
@@ -400,11 +402,11 @@
    "source": [
     "# Sensitivity analysis — read the LP duals at the optimum\n",
     "if problem.Status.name == \"Optimal\":\n",
-    "    print(\"Constraint duals — change in cost per unit change in the bound:\")\n",
+    "    print(\"Constraint duals — local marginal cost per unit of each limit (units differ per constraint):\")\n",
     "    for c in problem.getConstraints():\n",
     "        print(f\"  {c.ConstraintName:14s} dual={c.DualValue:+.4f}  slack={c.Slack:.4f}\")\n",
     "\n",
-    "    print(\"\\nReduced costs (variable duals) — for foods at 0, price drop needed to enter the diet:\")\n",
+    "    print(\"\\nReduced costs (variable duals) — for foods at 0, ~price drop before it could enter the diet:\")\n",
     "    for v in problem.getVariables():\n",
     "        print(f\"  {v.VariableName:12s} amount={v.getValue():7.3f}  reduced_cost={v.ReducedCost:+.4f}\")\n",
     "else:\n",
@@ -424,7 +426,7 @@
     "3. **Define an objective function** to minimize total cost\n",
     "4. **Add nutritional constraints** with both lower and upper bounds\n",
     "5. **Solve the optimization problem** using cuOpt's high-performance solver\n",
-    "6. **Read dual values and reduced costs** to quantify how sensitive the optimal cost is to each binding constraint\n",
+    "6. **Read dual values and reduced costs** for a local sensitivity read — which limits drive cost at the margin, and which unused foods sit closest to entering\n",
     "\n",
     "The cuOpt Python API provides a clean, intuitive interface for building and solving optimization problems, making it easy to model complex real-world scenarios like diet optimization.\n",
     "\n",

--- a/diet_optimization/diet_optimization_lp.ipynb
+++ b/diet_optimization/diet_optimization_lp.ipynb
@@ -521,7 +521,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n",
+    "SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n",
     "\n",
     "SPDX-License-Identifier: Apache-2.0\n",
     "\n",

--- a/diet_optimization/diet_optimization_lp.ipynb
+++ b/diet_optimization/diet_optimization_lp.ipynb
@@ -13,7 +13,7 @@
     "We need to select quantities of different foods to:\n",
     "- Meet minimum and maximum nutritional requirements\n",
     "- Minimize total cost\n",
-    "- Satisfy additional constraints (like limiting dairy servings)\n",
+    "- Satisfy additional constraints (like limiting red-meat servings)\n",
     "\n",
     "The nutrition guidelines are based on USDA Dietary Guidelines for Americans, 2005.\n"
    ]
@@ -417,7 +417,7 @@
    "source": [
     "## Adding Additional Constraints\n",
     "\n",
-    "Now let's demonstrate how to add additional constraints to the existing model. We'll add a constraint to limit dairy servings to at most 6.\n"
+    "Now let's add a constraint to the existing model and read its **shadow price**. We'll cap **hamburger + hot dog at 0.4 servings** combined — say, a red-meat preference — and re-solve."
    ]
   },
   {
@@ -426,9 +426,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create LinearExpression for dairy constraint\n",
-    "dairy_expr = buy_vars[\"milk\"] + buy_vars[\"ice cream\"]\n",
-    "dairy_constraint = problem.addConstraint(dairy_expr <= 6, name=\"limit_dairy\")"
+    "# Limit combined hamburger + hot dog servings (a red-meat preference)\n",
+    "meat_expr = buy_vars[\"hamburger\"] + buy_vars[\"hot dog\"]\n",
+    "meat_constraint = problem.addConstraint(meat_expr <= 0.4, name=\"limit_meat\")"
    ]
   },
   {
@@ -438,7 +438,7 @@
    "outputs": [],
    "source": [
     "# Solve the problem again with the new constraint\n",
-    "print(\"\\nSolving with dairy constraint...\")\n",
+    "print(\"\\nSolving with the meat constraint...\")\n",
     "print(f\"Problem now has {problem.NumVariables} variables and {problem.NumConstraints} constraints\")\n",
     "\n",
     "start_time = time.time()\n",
@@ -454,9 +454,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### The Shadow Price of the Dairy Cap\n",
+    "### The Shadow Price of the Meat Cap\n",
     "\n",
-    "We just capped dairy at 6 servings, and the cost rose. The cap's **dual** gives the marginal price of that limit directly — the change in total cost per additional serving of dairy allowed — without re-solving at every level."
+    "Capping hamburger and hot dog tightens the model and nudges the cost up. The cap's **dual** gives the marginal price of that limit directly — how much total cost changes per additional combined serving you allow — without re-solving at every level."
    ]
   },
   {
@@ -465,11 +465,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Marginal cost of the dairy cap, read straight off its dual\n",
+    "# Marginal cost of the meat cap, read straight off its dual\n",
     "if problem.Status.name == \"Optimal\":\n",
-    "    print(f\"limit_dairy shadow price: {dairy_constraint.DualValue:+.4f}  \"\n",
-    "          f\"(cost change per +1 serving of dairy allowed)\")\n",
-    "    print(f\"slack on the cap:         {dairy_constraint.Slack:.4f}   (0 means the cap is binding)\")"
+    "    print(f\"limit_meat shadow price: {meat_constraint.DualValue:+.4f}  \"\n",
+    "          f\"(cost change per +1 combined serving of hamburger/hot dog allowed)\")\n",
+    "    print(f\"slack on the cap:        {meat_constraint.Slack:.4f}   (0 means the cap is binding)\")"
    ]
   },
   {
@@ -478,7 +478,7 @@
    "source": [
     "## Solution Comparison\n",
     "\n",
-    "Let's compare the solutions before and after adding the dairy constraint to see the impact.\n"
+    "Let's compare the solutions before and after adding the meat cap to see the impact."
    ]
   },
   {

--- a/diet_optimization/diet_optimization_lp.ipynb
+++ b/diet_optimization/diet_optimization_lp.ipynb
@@ -388,7 +388,7 @@
     "\n",
     "Because every variable here is continuous, this is a linear program, and cuOpt returns dual information at the optimum — the economic \"why\" behind the plan:\n",
     "\n",
-    "- **Shadow price (constraint dual)** — how much the minimum cost changes per unit change in a constraint's bound. A *binding* nutrient floor has a nonzero shadow price; a slack constraint is approximately zero.\n",
+    "- **Shadow price (constraint dual)** — how much the minimum cost changes per unit change in a constraint's bound. A *binding* constraint has a nonzero shadow price; a slack one is approximately zero.\n",
     "- **Reduced cost (variable dual)** — for a food left out of the diet (amount 0), how much its per-serving price would have to fall before buying it could lower total cost."
    ]
   },

--- a/diet_optimization/diet_optimization_lp.ipynb
+++ b/diet_optimization/diet_optimization_lp.ipynb
@@ -521,7 +521,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n",
+    "SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n",
     "\n",
     "SPDX-License-Identifier: Apache-2.0\n",
     "\n",


### PR DESCRIPTION
## LP sensitivity analysis (dual values + reduced costs) — diet example

Extends the diet LP example to read the **dual information** cuOpt returns for a solved LP — the economic "why" behind the optimal plan. Motivated by **NVIDIA/cuopt#1393** (cuOpt's dual / sensitivity support per problem type: LP/QP, not integer models); companion to the QP efficient-frontier-with-duals example in **NVIDIA/cuopt-examples#151** (LP here, QP there).

- **`diet_optimization/diet_optimization_lp.ipynb`** — after the solve, reads each constraint's **dual value** (`DualValue`, `Slack`) and each variable's **reduced cost** (`ReducedCost`) via `problem.getConstraints()` / `problem.getVariables()`, with a plain-language binding-vs-slack reading: which nutrition limits drive the cost, and how far each unused food is from entering the diet. The diet model itself is unchanged. `diet_optimization/README.md` updated to match.

Runs on cuOpt alone (Colab GPU), follows the repo's notebook idiom (GPU check → `cuopt-cu12` install → solve), and ships **output-stripped** (repo convention); run evidence below.

### User testing

Run end-to-end on a **Colab GPU runtime (`cuopt-cu12`) — clean, no errors**: solve is `Optimal` at **\$11.83**. The binding constraints here price nonzero — `min_protein +0.093`, `min_calories +0.003`, `max_sodium −0.002` — while slack ones price to ~0; every food left out of the diet shows a positive reduced cost (`macaroni +1.34` the largest), the price drop before it could enter the diet.

<details><summary>raw cell output</summary>

```
Constraint duals — local marginal cost per unit of each limit (units differ per constraint):
  min_calories   dual=+0.0034  slack=-0.0000
  max_calories   dual=+0.0000  slack=400.0000
  min_protein    dual=+0.0930  slack=-0.0000
  min_fat        dual=+0.0000  slack=-59.0559
  max_fat        dual=+0.0000  slack=5.9441
  min_sodium     dual=+0.0000  slack=-1779.0000
  max_sodium     dual=-0.0016  slack=0.0000

Reduced costs (variable duals) — for foods at 0, ~price drop before it could enter the diet:
  hamburger    amount=  0.605  reduced_cost=+0.0001
  chicken      amount=  0.000  reduced_cost=+0.3425
  hot dog      amount=  0.000  reduced_cost=+0.5456
  fries        amount=  0.000  reduced_cost=+0.6421
  macaroni     amount=  0.000  reduced_cost=+1.3371
  pizza        amount=  0.000  reduced_cost=+0.7857
  salad        amount=  0.000  reduced_cost=+0.4400
  milk         amount=  6.970  reduced_cost=-0.0000
  ice cream    amount=  2.591  reduced_cost=-0.0000
```
</details>

### Notes
- **Dual values are LP/QP only** — valid here because every variable is continuous; an integer model returns none.
- **Output-stripped** per repo convention; re-run on a GPU runtime to reproduce the numbers above.
