### PR TITLE
cuopt-agent: multi-objective supply-vs-cost what-if + cost-cap eval

### DIFF
--- a/cuopt-agent/cuopt_agent/data/max_supply_what_ifs/eval/max_supply_what_ifs.csv
+++ b/cuopt-agent/cuopt_agent/data/max_supply_what_ifs/eval/max_supply_what_ifs.csv
@@ -104,4 +104,6 @@ Constrain `total_cost <= 9149.8` and re-solve for the model's existing objective
 priority-weighted finished-goods inventory at the end of the horizon) on the sample dataset
 (10 periods).
 
-Report the resulting optimal objective value.","2660000"
+Report the resulting optimal objective value, solving to proven optimality (tighten
+`mip_relative_gap` to 0 — at the default 1% gap the solver can stop on a suboptimal
+incumbent inside the gap).","2670000"

--- a/cuopt-agent/cuopt_agent/data/max_supply_what_ifs/eval/max_supply_what_ifs.csv
+++ b/cuopt-agent/cuopt_agent/data/max_supply_what_ifs/eval/max_supply_what_ifs.csv
@@ -83,3 +83,25 @@ Analyse the results:
 2. How does the additional material improve the objective value?
 3. Does RM4 inventory carry across multiple periods, or is it consumed quickly?
 4. What would happen if the shipment were moved to week 5 instead of week 2?","3470065"
+"max_supply_4","## Scenario
+
+The max-supply model maximizes priority-weighted finished-goods inventory but ignores what
+production costs. Finance needs to know how much supply is reachable under a fixed budget.
+
+## Request
+
+Add a total-cost accounting to the model from `item_costs.csv` (`unit_cost`, `holding_cost`) and
+`resource_costs.csv` (`production_cost_per_hour`), defined over the model's existing variables — no
+new decisions:
+
+```
+total_cost = sum over procured i, period t of  buy[i,t] * unit_cost[i]                       (procurement)
+           + sum over all items i, period t of inventory[i,t] * holding_cost[i]              (holding)
+           + sum over (process p, resource r), period t of x[p,r,t] * hours_per_unit[p] * production_cost_per_hour[r]   (production)
+```
+
+Constrain `total_cost <= 9149.8` and re-solve for the model's existing objective (maximize
+priority-weighted finished-goods inventory at the end of the horizon) on the sample dataset
+(10 periods).
+
+Report the resulting optimal objective value.","2660000"

--- a/cuopt-agent/cuopt_agent/data/max_supply_what_ifs/sample_prompts/scenario_4.md
+++ b/cuopt-agent/cuopt_agent/data/max_supply_what_ifs/sample_prompts/scenario_4.md
@@ -1,0 +1,29 @@
+## Scenario
+
+Our max-supply model maximizes priority-weighted finished-goods inventory at the end of the
+horizon — but it spends freely to do it. Procuring more raw material, running resources longer,
+and carrying inventory all cost money (`item_costs.csv` has per-item `unit_cost` and `holding_cost`;
+`resource_costs.csv` has `production_cost_per_hour`), and the base objective ignores all of it.
+
+Finance now wants the cost side on the table. There is **no agreed exchange rate** between a unit of
+finished-goods supply and a dollar of cost — pushing supply up raises cost, and the right balance is
+a judgment call, not a number we can hand the solver up front. So the answer finance needs isn't a
+single plan; it's the tradeoff laid out so they can choose where to sit.
+
+## Request
+
+1. Bring cost into the picture as a reporting quantity built from `item_costs.csv` and
+   `resource_costs.csv` over the model's existing variables — no new decisions.
+
+2. Give finance the **whole supply-vs-cost tradeoff**, not one plan and not a single blended
+   objective: show how much finished-goods supply each budget level buys, from a tight budget up to
+   where more money stops buying more supply.
+
+3. Solve on the sample dataset (10 periods) and present it so finance can act: the tradeoff curve,
+   the rate at which supply is bought as the budget loosens and where that rate falls off (the knee),
+   what drives cost at the high-supply end, and two or three candidate operating points to choose
+   between — without calling any one of them "best."
+
+Watch two things about this model so the numbers mean what you claim: it's a **MILP**, and the
+finished-goods priority weights span 10000:1 — so make sure your marginal rate is valid for the model
+class and your supply figures are in terms finance can read, not just the weighted total.

--- a/cuopt-agent/cuopt_agent/data/max_supply_what_ifs/sample_prompts/scenario_4.md
+++ b/cuopt-agent/cuopt_agent/data/max_supply_what_ifs/sample_prompts/scenario_4.md
@@ -15,9 +15,10 @@ single plan; it's the tradeoff laid out so they can choose where to sit.
 1. Bring cost into the picture as a reporting quantity built from `item_costs.csv` and
    `resource_costs.csv` over the model's existing variables — no new decisions.
 
-2. Give finance the **whole supply-vs-cost tradeoff**, not one plan and not a single blended
-   objective: show how much finished-goods supply each budget level buys, from a tight budget up to
-   where more money stops buying more supply.
+2. Give finance the **supply-vs-cost tradeoff across the budget range**, not one plan and not a
+   single blended objective: show how much finished-goods supply each budget level buys, from a
+   tight budget up to where more money stops buying more supply. (A budget sweep samples the
+   curve — on a MILP it is a step function, so present sampled points, not an interpolated line.)
 
 3. Solve on the sample dataset (10 periods) and present it so finance can act: the tradeoff curve,
    the rate at which supply is bought as the budget loosens and where that rate falls off (the knee),


### PR DESCRIPTION
## What

A new what-if scenario (`scenario_4.md`) and eval case (`max_supply_4`) for the cuopt-agent's max-supply model — bringing multi-objective tradeoff exploration to the agent.

## Why

The agent ships a multi-period MILP whose cost data (`item_costs.csv`, `resource_costs.csv`) is unused, and it only ever runs single-objective; the `cuopt-multi-objective-exploration` skill (**NVIDIA/cuopt#1355**) is available but no scenario exercises it. `scenario_4` activates it as a supply-vs-cost tradeoff with no agreed weighting, framed to test judgment rather than prescribe the method (it surfaces the MILP-has-no-duals and 10000:1-weight traps without naming ε-constraint). `max_supply_4` adds a numeric check graded by the existing `cuopt_objective` evaluator: cap total cost at 9,149.8 and maximize supply, ground truth **2,660,000**, computed on cuOpt (Tesla T4).

## User testing

Run on cuOpt (Tesla T4):
- The reference solve traces a well-posed supply-vs-cost frontier — supply buys in at ~288 weighted-units/$, then collapses to ~7/$ past the FG1-saturation knee (full sweep below).
- Before/after, same LLM: without the skill the agent collapses to a self-weighted blend (`maximize supply − λ·cost`); with `scenario_4` + the skill it traces the frontier by ε-constraint, differences adjacent points for the rate (correctly noting a MILP has no duals), reports interpretable units, flags the knee, and leaves the pick to finance — and its solve hit the eval ground truth.

<details><summary>Reference frontier — max weighted supply vs. cost cap (cuOpt, Tesla T4); unconstrained max 3,450,061 at cost 15,249.6</summary>

| total cost ≤ C | max weighted obj | FG1 | FG2 | Δobj/Δ$ |
|---|---|---|---|---|
| 3,812 | 1,140,000 | 114 | 0 | — |
| 5,168 | 1,530,000 | 153 | 0 | 288 |
| 6,523 | 1,920,000 | 192 | 0 | 288 |
| 7,879 | 2,300,000 | 230 | 0 | 280 |
| 9,235 | 2,690,000 | 269 | 0 | 288 |
| 10,590 | 3,020,000 | 302 | 0 | 243 |
| 11,946 | 3,300,001 | 330 | 1 | 207 |
| 13,301 | 3,440,006 | 344 | 6 | 103 |
| 14,657 | 3,450,063 | 345 | 63 | **7** |
| 16,012 | 3,460,062 | 346 | 62 | **7** |

</details>

Toy sample data — exercises the multi-objective method on the agent, not a planning study.
