### PR TITLE
cuopt-agent: update reasoning LLM to minimaxai/minimax-m3

### DIFF
--- a/cuopt-agent/README.md
+++ b/cuopt-agent/README.md
@@ -42,7 +42,7 @@ The cuOpt Agent is a reference optimization assistant that translates natural-la
 | [NVIDIA NeMo Agent Toolkit](https://docs.nvidia.com/nemo/agent-toolkit/latest/) | Agent framework and serving |
 | [NVIDIA cuOpt](https://developer.nvidia.com/cuopt) | GPU-accelerated LP/MILP solver |
 | [LangChain Deep Agents](https://www.langchain.com/) | Multi-step agent workflow |
-| [minimaxai/minimax-m2.5](https://build.nvidia.com/) (via NIM) | LLM for agent reasoning |
+| [minimaxai/minimax-m3](https://build.nvidia.com/) (via NIM) | LLM for agent reasoning |
 | [Phoenix](https://github.com/Arize-ai/phoenix) | OpenTelemetry tracing |
 | [LangSmith](https://smith.langchain.com/) (optional) | Agent tracing and observability |
 | [NAT UI](external/nat-ui/) | Chat web interface |

--- a/cuopt-agent/cuopt_agent/configs/config-deepagent-eval.yml
+++ b/cuopt-agent/cuopt_agent/configs/config-deepagent-eval.yml
@@ -34,7 +34,7 @@ general:
 llms:
   cuopt_llm:
     _type: nim
-    model: minimaxai/minimax-m2.5
+    model: minimaxai/minimax-m3
     api_key: ${NVIDIA_API_KEY}
     base_url: https://integrate.api.nvidia.com/v1/
     max_tokens: 16384    

--- a/cuopt-agent/cuopt_agent/configs/config-deepagent.yml
+++ b/cuopt-agent/cuopt_agent/configs/config-deepagent.yml
@@ -41,7 +41,7 @@ general:
 llms:
   cuopt_llm:
     _type: nim
-    model: minimaxai/minimax-m2.5
+    model: minimaxai/minimax-m3
     api_key: ${NVIDIA_API_KEY}
     base_url: https://integrate.api.nvidia.com/v1/
     max_tokens: 16384


### PR DESCRIPTION
## What

Updates the cuopt-agent's reasoning LLM from `minimaxai/minimax-m2.5` to `minimaxai/minimax-m3` in both configs (`config-deepagent.yml`, `config-deepagent-eval.yml`) and the README model table.

## Why

`minimaxai/minimax-m2.5` has been **deprecated** on the `integrate.api.nvidia.com` NIM endpoint the agent points at by default, so the shipped config no longer runs against it. `minimaxai/minimax-m3` is the current MiniMax model there — confirmed working in a live call (it produced the expected multi-objective reasoning and its solve grounded correctly on cuOpt). This restores a fresh clone's ability to run against the default endpoint.
