### PR TITLE
cuopt-agent: add duals-interpretation guidance to the debugging skill

### DIFF
--- a/cuopt-agent/skills/max-supply/cuopt-debugging/SKILL.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/SKILL.md
@@ -201,9 +201,9 @@ See [resources/diagnostic_snippets.md](resources/diagnostic_snippets.md) for cop
 - Constraint analysis
 - Memory and performance checks
 
-## Interpreting Duals (Shadow Prices & Reduced Costs)
+## Interpreting Duals (Marginal Values & Reduced Costs)
 
-When an LP/QP solve returns dual values and you need the *decision* read — which constraint is the binding bottleneck, what relaxing it is worth, and which unused option is the closest near-miss — see [resources/interpreting_duals.md](resources/interpreting_duals.md). (Integer models / MILP return no usable duals; that reference covers the MILP fallback.)
+When an LP/QP solve returns dual values and you need the *decision* read — which constraint is the binding bottleneck, what relaxing it is worth, and which unused option is the closest near-miss — see [resources/interpreting_duals.md](resources/interpreting_duals.md). (Integer models / MILP — and quadratic *constraints* — return no usable duals; that reference covers the fallback.)
 
 ## When to Escalate
 

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/SKILL.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/SKILL.md
@@ -201,6 +201,10 @@ See [resources/diagnostic_snippets.md](resources/diagnostic_snippets.md) for cop
 - Constraint analysis
 - Memory and performance checks
 
+## Interpreting Duals (Shadow Prices & Reduced Costs)
+
+When an LP/QP solve returns dual values and you need the *decision* read — which constraint is the binding bottleneck, what relaxing it is worth, and which unused option is the closest near-miss — see [resources/interpreting_duals.md](resources/interpreting_duals.md). (Integer models / MILP return no usable duals; that reference covers the MILP fallback.)
+
 ## When to Escalate
 
 File a GitHub issue if:

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/SKILL.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/SKILL.md
@@ -201,7 +201,7 @@ See [resources/diagnostic_snippets.md](resources/diagnostic_snippets.md) for cop
 - Constraint analysis
 - Memory and performance checks
 
-## Interpreting Duals (Marginal Values & Reduced Costs)
+## Interpreting Dual Values & Reduced Costs
 
 When an LP/QP solve returns dual values and you need the *decision* read — which constraint is the binding bottleneck, what relaxing it is worth, and which unused option is the closest near-miss — see [resources/interpreting_duals.md](resources/interpreting_duals.md). (Integer models / MILP — and quadratic *constraints* — return no usable duals; that reference covers the fallback.)
 

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -16,9 +16,10 @@ closest near-miss."
 
 ## Constraint dual value — the marginal value of relaxing a limit
 
-A constraint's `DualValue` is the **sensitivity** of the optimum to that constraint: the change in
-the optimal objective per unit relaxation of its right-hand side, holding everything else fixed —
-the marginal value of one more unit of that limit.
+A constraint's `DualValue` is the **sensitivity** of the optimum to that constraint: the marginal
+value of one more unit of that limit, holding everything else fixed. At a non-degenerate optimum
+that is the exact change in objective per unit relaxed; under **degeneracy** (common in practice) it
+is one-sided, so read it as a direction (see *When a dual is soft*).
 
 - A **binding** constraint (`Slack ≈ 0`) carries a nonzero dual — it is actively limiting
   the objective. A **slack** constraint (`Slack > 0`) prices to ~0: relaxing it changes

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -27,16 +27,17 @@ finite relaxation, difference two solves.
   relaxing it changes nothing, because it is not the bottleneck. But `Slack ≈ 0` does **not**
   guarantee a nonzero dual: a binding constraint can still price to 0 (a form of degeneracy — see
   *When a dual is soft*).
-- **Rank the binding constraints by `|DualValue|`** → the largest is the highest-leverage limit to
-  renegotiate. The *ranking* is the robust read; a single dual is a direction, not a guaranteed
-  per-unit rate (see *When a dual is soft*). One catch: a dual is objective-units **per unit of
+- **Rank the binding constraints by `|DualValue|`** → a shortlist of the highest-leverage limits to
+  renegotiate. Treat it as a shortlist, not a verdict: under degeneracy the dual solution itself is
+  non-unique, so even the ordering can shift between equally optimal solves — confirm the top
+  lever with a differencing re-solve (see *When a dual is soft*). One catch: a dual is objective-units **per unit of
   that constraint**, so the raw ranking only makes sense across constraints in **comparable units**
   (hours vs hours). To rank a machine-hour cap against a material-tonnage limit, put them on a
   common scale first — e.g. multiply each dual by a realistic relaxation step, or compare the value
   of a 1% relaxation (`|DualValue| × 0.01 × |RHS|`).
 
 ```python
-# Which constraints bind, and what each is worth (LP / QP only).
+# Which constraints bind, and each one's returned dual (LP / QP only).
 # The |dual| ranking is meaningful within comparable-unit constraints:
 binding = [(c.ConstraintName, c.DualValue) for c in problem.getConstraints() if abs(c.Slack) < 1e-6]
 for name, dual in sorted(binding, key=lambda kv: -abs(kv[1])):
@@ -52,16 +53,20 @@ as a guide and difference two MILP solves for the real number.)
 
 ## Reduced cost — how far an unused option is from being worth using
 
-A variable resting at a bound (often `0`) carries a `ReducedCost`: improve its objective
-coefficient by more than `|ReducedCost|` and the current plan stops being optimal — using that
-variable starts to pay off; by less, and leaving it at its bound stays optimal. It is the
-**near-miss** signal.
+A variable resting at a bound (often `0`) carries a `ReducedCost` — a one-way threshold on its
+objective coefficient: improve the coefficient by **less** than `|ReducedCost|` and leaving the
+variable at its bound stays optimal; improve it by more and using the variable **can** start to
+pay off. (The returned value certifies the first direction, not the second — degeneracy again.)
+It is the **near-miss** signal.
 
-- A variable with `Value > 0` is already in the mix; its reduced cost is ~0.
+- A variable strictly **between** its bounds prices to ~0. One pressed against an *upper* bound can
+  carry a nonzero reduced cost with `Value > 0` — there it reads as the marginal value of raising
+  that bound.
 - A variable **at its bound** can also price to ~0 — degeneracy again: an alternative optimum uses
   it with no coefficient change at all (the mirror of a binding constraint with a zero dual).
-- Among the variables left at `0`, the one with the **smallest `|ReducedCost|`** is closest to
-  becoming worthwhile — the option to watch if a cost or yield shifts slightly. Same units catch as
+- Among the variables left at `0` with a clearly nonzero reduced cost, the one with the
+  **smallest `|ReducedCost|`** is closest to becoming worthwhile — the option to watch if a cost
+  or yield shifts slightly. Same units catch as
   the dual ranking: a reduced cost is objective-units per unit of *that variable*, so sort only
   variables in comparable units against each other — or compare each `|ReducedCost|` as a fraction
   of its own objective coefficient ("needs a 3% price move" vs "needs a 40% one").
@@ -78,11 +83,11 @@ for name, rc in sorted(near, key=lambda kv: abs(kv[1])):
 
 ## The decision read
 
-Two questions answered straight from the duals:
+Two questions the duals point to — confirm any number you quote with a differencing re-solve:
 
 - **Where to invest / what to renegotiate** — the binding constraint with the largest dual among
-  comparable-unit limits (or after the common-scale conversion above). Relaxing that limit improves the
-  objective at the highest marginal rate.
+  comparable-unit limits (or after the common-scale conversion above): the first lever to test
+  for relaxing.
 - **The closest near-miss** — the unused option with the smallest reduced cost, compared in like
   units or as a fraction of its own coefficient. The first thing that would enter the plan if the
   economics shift.
@@ -104,8 +109,10 @@ convergence tolerance, with no basis behind them. Those duals get the same treat
 direction, not exact rates, and at-bound reduced costs are not the crisp zero / nonzero split a
 simplex basis gives.
 
-- Report the **ranking** of binding constraints (within comparable units) as solid; present a
-  single dual as a *direction* ("this is the lever to renegotiate"), not a hard per-unit rate.
+- Use the **ranking** of binding constraints (within comparable units) as a shortlist and a single
+  dual as a *direction* ("this is the lever to renegotiate"), not a hard per-unit rate — the dual
+  solution is non-unique under degeneracy, so even the ordering can shift between equally optimal
+  solves. Confirm the lever you act on with a differencing re-solve.
 - Quote a finite change only from a differencing re-solve: the dual is the rate at the current
   optimum, and the realized change over a step can differ from `dual × step` (the active set can
   change along the way, degenerate or not).

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -1,18 +1,20 @@
 # Interpreting Dual Values, Reduced Costs, and Slack
 
 `diagnostic_snippets.md` shows how to *read* `DualValue`, `ReducedCost`, and `Slack` off a solved
-problem. This explains what they *mean* for the decision — turning solver output into "which
+problem. This page explains what they *mean* for the decision — turning solver output into "which
 constraint is the binding bottleneck, what relaxing it is worth, and which unused option is the
 closest near-miss."
 
 > **Continuous models, linear constraints.** Duals and reduced costs exist for **continuous**
-> (LP / QP) solutions off **linear** constraints. Two cases return none: an **integer model
-> (MILP)** — **including the max-supply model** — has no usable duals, and a **quadratic
-> _constraint_** makes cuOpt NaN-fill every dual (a quadratic _objective_ is fine — it is a
-> quadratic _constraint_ that breaks them). `DualValue` / `ReducedCost` are not meaningful in
-> either case. For a MILP, get the value of one more unit by **differencing adjacent solves** (re-solve
-> with the bound relaxed by one unit and compare objectives); duals of the **LP relaxation** are a
-> quicker guide, but the integer optimum can respond differently — differencing is the ground truth.
+> (LP / QP) solutions off **linear** constraints — an **integer model (MILP)**, **including the
+> max-supply model**, returns none. The canonical availability rule (including the
+> quadratic-constraint case) lives in the `cuopt-numerical-optimization-api` skill under *Dual
+> Values* — this page defers to it rather than restating it. At runtime, key off the returned
+> values: finite duals are provided, NaN-filled duals are not — a check that stays correct
+> across releases. For a MILP, get the value of one more unit by **differencing adjacent
+> solves** (re-solve with the bound relaxed by one unit and compare objectives); duals of the
+> **LP relaxation** are a quicker guide, but the integer optimum can respond differently —
+> differencing is the ground truth.
 
 ## Constraint dual value — the marginal value of relaxing a limit
 
@@ -45,7 +47,8 @@ for name, dual in sorted(binding, key=lambda kv: -abs(kv[1])):
     print(f"{name}: dual {dual:+.4g}  (marginal rate as this limit relaxes)")
 ```
 
-In the max-supply shape the constraints that typically bind are the **resource-hour capacities**
+In the max-supply model — this agent's multi-period supply-chain planning example — the
+constraints that typically bind are the **resource-hour capacities**
 and the **per-period supply limits** — the dual prices each one: the marginal rate, in
 finished-goods terms, at which a tight resource period (e.g. `RES2`) or a material's supply limit
 pays off as it relaxes. Hour-caps rank against hour-caps and supply limits against supply limits;
@@ -61,8 +64,8 @@ pay off. (The returned value certifies the first direction, not the second — d
 It is the **near-miss** signal.
 
 - A variable strictly **between** its bounds prices to ~0. One pressed against an *upper* bound can
-  carry a nonzero reduced cost with `Value > 0` — there it reads as the marginal value of raising
-  that bound.
+  carry a nonzero reduced cost with `Value > 0` — there its **magnitude** is the marginal value of
+  raising that bound; read the direction as for any bound relaxation (see *Sign conventions*).
 - A variable **at its bound** can also price to ~0 — degeneracy again: an alternative optimum uses
   it with no coefficient change at all (the mirror of a binding constraint with a zero dual).
 - Among the variables left at `0` with a clearly nonzero reduced cost, the one with the
@@ -99,16 +102,16 @@ bottleneck — each extra hour is worth ~`X` finished units; *material Y* is the
 
 ## When a dual is soft (degeneracy)
 
-A dual is exact for the basis the solver returned, but at a **degenerate** optimum — many
+A simplex dual is exact for the basis the solver returned, but at a **degenerate** optimum — many
 constraints binding at once (a lot of `Slack ≈ 0`) — that basis is one of several, so the dual is
 one-sided and non-unique. It reads most precise exactly where it is least reliable, the common case
 on large LPs.
 
 Which solver ran matters too: cuOpt **often returns no basis at all** — the first-order **PDLP**
 path (common on large LPs, and one arm of the concurrent default) produces duals only to the
-convergence tolerance, with no basis behind them. Those duals get the same treatment: leverage and
-direction, not exact rates, and at-bound reduced costs are not the crisp zero / nonzero split a
-simplex basis gives.
+convergence tolerance, and the same holds for any **barrier** / interior-point solve without
+crossover. Basis-free duals get the same treatment: leverage and direction, not exact rates, and
+at-bound reduced costs are not the crisp zero / nonzero split a simplex basis gives.
 
 - Use the **ranking** of binding constraints (within comparable units) as a shortlist and a single
   dual as a *direction* ("this is the lever to renegotiate"), not a hard per-unit rate — the dual

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -1,23 +1,27 @@
-# Interpreting Duals: Shadow Prices, Reduced Costs, and Slack
+# Interpreting Duals: Marginal Values, Reduced Costs, and Slack
 
 `diagnostic_snippets.md` shows how to *read* `DualValue`, `ReducedCost`, and `Slack` off a solved
 problem. This explains what they *mean* for the decision — turning solver output into "which
 constraint is the binding bottleneck, what relaxing it is worth, and which unused option is the
 closest near-miss."
 
-> **LP / QP only.** Duals and reduced costs exist for **continuous** (LP / QP) solutions. An
-> integer model (MILP) — **including the max-supply model** — returns no usable duals;
-> `DualValue` / `ReducedCost` are not meaningful there. For a MILP, get the marginal value by
-> **differencing adjacent solves** (re-solve with the bound relaxed by one unit and compare
-> objectives), or read duals from the **LP relaxation**.
+> **Continuous models, linear constraints.** Duals and reduced costs exist for **continuous**
+> (LP / QP) solutions off **linear** constraints. Two cases return none: an **integer model
+> (MILP)** — **including the max-supply model** — has no usable duals, and a **quadratic
+> _constraint_** makes cuOpt NaN-fill every dual (a quadratic _objective_ is fine — it is a
+> quadratic _constraint_ that breaks them). `DualValue` / `ReducedCost` are not meaningful in
+> either case. For a MILP, get the marginal value by **differencing adjacent solves** (re-solve
+> with the bound relaxed by one unit and compare objectives), or read duals from the **LP
+> relaxation**.
 
-## Shadow price — the value of relaxing a constraint
+## Constraint dual — the marginal value of relaxing a limit
 
-A constraint's `DualValue` is its **shadow price**: the change in the optimal objective per unit
-relaxation of that constraint's right-hand side, holding everything else fixed.
+A constraint's `DualValue` is the **sensitivity** of the optimum to that constraint: the change in
+the optimal objective per unit relaxation of its right-hand side, holding everything else fixed —
+the marginal value of one more unit of that limit (classically, its *shadow price*).
 
-- A **binding** constraint (`Slack ≈ 0`) carries a nonzero shadow price — it is actively limiting
-  the objective. A **slack** constraint (`Slack > 0`) has a shadow price of ~0: relaxing it changes
+- A **binding** constraint (`Slack ≈ 0`) carries a nonzero dual — it is actively limiting
+  the objective. A **slack** constraint (`Slack > 0`) prices to ~0: relaxing it changes
   nothing, because it is not the bottleneck.
 - **Rank the binding constraints by `|DualValue|`** → the largest is the highest-leverage limit to
   renegotiate: "relax this by one unit and the objective improves by `DualValue`."
@@ -26,11 +30,11 @@ relaxation of that constraint's right-hand side, holding everything else fixed.
 # Which constraints bind, and what each is worth (LP / QP only):
 binding = [(c.ConstraintName, c.DualValue) for c in problem.getConstraints() if abs(c.Slack) < 1e-6]
 for name, dual in sorted(binding, key=lambda kv: -abs(kv[1])):
-    print(f"{name}: shadow price {dual:+.4g}  (objective change per unit relaxed)")
+    print(f"{name}: dual {dual:+.4g}  (objective change per unit relaxed)")
 ```
 
 In the max-supply shape the constraints that typically bind are the **resource-hour capacities**
-and the **per-period supply limits** — the shadow price tells you which machine-hour (e.g. a tight
+and the **per-period supply limits** — the dual tells you which machine-hour (e.g. a tight
 `RES2` period) or which material is the binding bottleneck, and what one more hour or unit of supply
 is worth in finished-goods terms. (Read it from the LP relaxation, since the model itself is a MILP.)
 
@@ -55,7 +59,7 @@ for name, rc in sorted(near, key=lambda kv: abs(kv[1])):
 
 Two questions answered straight from the duals:
 
-- **Where to invest / what to renegotiate** — the binding constraint with the largest shadow price.
+- **Where to invest / what to renegotiate** — the binding constraint with the largest dual.
   Lift that limit and you gain the most per unit.
 - **The closest near-miss** — the unused option with the smallest reduced cost. The first thing that
   would enter the plan if the economics shift.

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -25,7 +25,8 @@ is one-sided, so read it as a direction (see *When a dual is soft*).
   the objective. A **slack** constraint (`Slack > 0`) prices to ~0: relaxing it changes
   nothing, because it is not the bottleneck.
 - **Rank the binding constraints by `|DualValue|`** → the largest is the highest-leverage limit to
-  renegotiate: "relax this by one unit and the objective improves by `DualValue`."
+  renegotiate. The *ranking* is the robust read; a single dual is a direction, not a guaranteed
+  per-unit rate (see *When a dual is soft*).
 
 ```python
 # Which constraints bind, and what each is worth (LP / QP only):

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -7,14 +7,13 @@ closest near-miss."
 
 > **Continuous models, linear constraints.** Duals and reduced costs exist for **continuous**
 > (LP / QP) solutions off **linear** constraints — an **integer model (MILP)**, **including the
-> max-supply model**, returns none. The canonical availability rule (including the
-> quadratic-constraint case) lives in the `cuopt-numerical-optimization-api` skill under *Dual
-> Values* — this page defers to it rather than restating it. At runtime, key off the returned
-> values: finite duals are provided, NaN-filled duals are not — a check that stays correct
-> across releases. For a MILP, get the value of one more unit by **differencing adjacent
-> solves** (re-solve with the bound relaxed by one unit and compare objectives); duals of the
-> **LP relaxation** are a quicker guide, but the integer optimum can respond differently —
-> differencing is the ground truth.
+> max-supply model**, returns none. The full availability rule (including the
+> quadratic-constraint case) is in the `cuopt-numerical-optimization-api` skill under *Dual
+> Values*. At runtime, key off the returned values: finite duals are provided, NaN-filled are
+> not. For a MILP, get the value of one more unit by **differencing adjacent solves** (re-solve
+> with the bound relaxed by one unit and compare objectives); duals of the **LP relaxation**
+> are a quicker guide, but the integer optimum can respond differently — differencing is the
+> ground truth.
 
 ## Constraint dual value — the marginal value of relaxing a limit
 

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -1,4 +1,4 @@
-# Interpreting Duals: Marginal Values, Reduced Costs, and Slack
+# Interpreting Dual Values, Reduced Costs, and Slack
 
 `diagnostic_snippets.md` shows how to *read* `DualValue`, `ReducedCost`, and `Slack` off a solved
 problem. This explains what they *mean* for the decision — turning solver output into "which
@@ -14,11 +14,11 @@ closest near-miss."
 > with the bound relaxed by one unit and compare objectives), or read duals from the **LP
 > relaxation**.
 
-## Constraint dual — the marginal value of relaxing a limit
+## Constraint dual value — the marginal value of relaxing a limit
 
 A constraint's `DualValue` is the **sensitivity** of the optimum to that constraint: the change in
 the optimal objective per unit relaxation of its right-hand side, holding everything else fixed —
-the marginal value of one more unit of that limit (classically, its *shadow price*).
+the marginal value of one more unit of that limit.
 
 - A **binding** constraint (`Slack ≈ 0`) carries a nonzero dual — it is actively limiting
   the objective. A **slack** constraint (`Slack > 0`) prices to ~0: relaxing it changes

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -44,15 +44,15 @@ for name, dual in sorted(binding, key=lambda kv: -abs(kv[1])):
 ```
 
 In the max-supply shape the constraints that typically bind are the **resource-hour capacities**
-and the **per-period supply limits** — the dual prices each one: what one more hour of a tight
-resource period (e.g. `RES2`), or one more unit of a material's supply, is worth in finished-goods
-terms. Hour-caps rank against hour-caps and supply limits against supply limits; across the two,
+and the **per-period supply limits** — the dual prices each one: the marginal rate, in
+finished-goods terms, at which a tight resource period (e.g. `RES2`) or a material's supply limit
+pays off as it relaxes. Hour-caps rank against hour-caps and supply limits against supply limits; across the two,
 convert to a common scale first. (Read it from the LP relaxation, since the model itself is a MILP.)
 
 ## Reduced cost — how far an unused option is from entering
 
 A variable resting at a bound (often `0`) carries a `ReducedCost`: how much its objective
-coefficient must improve before it would enter the optimal solution. It is the **near-miss** signal.
+coefficient must improve before it could enter the optimal solution. It is the **near-miss** signal.
 
 - A variable with `Value > 0` is already in the mix; its reduced cost is ~0.
 - Among the variables left at `0`, the one with the **smallest `|ReducedCost|`** is closest to
@@ -103,7 +103,6 @@ simplex basis gives.
 - Quote a finite change only from a differencing re-solve: the dual is the rate at the current
   optimum, and the realized change over a step can differ from `dual × step` (the active set can
   change along the way, degenerate or not).
-
 
 ## Sign conventions
 

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -24,7 +24,7 @@ is one-sided, so read it as a direction (see *When a dual is soft*).
 - The implication runs **one way**: a **slack** constraint (`Slack > 0`) always prices to ~0 —
   relaxing it changes nothing, because it is not the bottleneck. But `Slack ≈ 0` does **not**
   guarantee a nonzero dual: a binding constraint can still price to 0 (a form of degeneracy — see
-  *When a dual is soft*). A nonzero dual means binding; binding does not mean a nonzero dual.
+  *When a dual is soft*).
 - **Rank the binding constraints by `|DualValue|`** → the largest is the highest-leverage limit to
   renegotiate. The *ranking* is the robust read; a single dual is a direction, not a guaranteed
   per-unit rate (see *When a dual is soft*). One catch: a dual is objective-units **per unit of
@@ -34,16 +34,18 @@ is one-sided, so read it as a direction (see *When a dual is soft*).
   of a 1% relaxation (`|DualValue| × 0.01 × |RHS|`).
 
 ```python
-# Which constraints bind, and what each is worth (LP / QP only):
+# Which constraints bind, and what each is worth (LP / QP only).
+# The |dual| ranking is meaningful within comparable-unit constraints:
 binding = [(c.ConstraintName, c.DualValue) for c in problem.getConstraints() if abs(c.Slack) < 1e-6]
 for name, dual in sorted(binding, key=lambda kv: -abs(kv[1])):
     print(f"{name}: dual {dual:+.4g}  (objective change per unit relaxed)")
 ```
 
 In the max-supply shape the constraints that typically bind are the **resource-hour capacities**
-and the **per-period supply limits** — the dual tells you which machine-hour (e.g. a tight
-`RES2` period) or which material is the binding bottleneck, and what one more hour or unit of supply
-is worth in finished-goods terms. (Read it from the LP relaxation, since the model itself is a MILP.)
+and the **per-period supply limits** — the dual prices each one: what one more hour of a tight
+resource period (e.g. `RES2`), or one more unit of a material's supply, is worth in finished-goods
+terms. Hour-caps rank against hour-caps and supply limits against supply limits; across the two,
+convert to a common scale first. (Read it from the LP relaxation, since the model itself is a MILP.)
 
 ## Reduced cost — how far an unused option is from entering
 
@@ -58,21 +60,24 @@ coefficient must improve before it would enter the optimal solution. It is the *
   of its own objective coefficient ("needs a 3% price move" vs "needs a 40% one").
 
 ```python
-# Unused options ranked by how close they are to entering (LP / QP only):
+# Unused options ranked by how close they are to entering (LP / QP only).
+# Compare |reduced cost| within comparable-unit variables:
 near = [(v.VariableName, v.ReducedCost) for v in problem.getVariables()
         if abs(v.Value) < 1e-6 and abs(v.ReducedCost) > 1e-9]
 for name, rc in sorted(near, key=lambda kv: abs(kv[1])):
-    print(f"{name}: reduced cost {rc:+.4g}  (improve its coefficient by ~{abs(rc):.4g} to use it)")
+    print(f"{name}: reduced cost {rc:+.4g}  (~{abs(rc):.4g} coefficient improvement before it could enter)")
 ```
 
 ## The decision read
 
 Two questions answered straight from the duals:
 
-- **Where to invest / what to renegotiate** — the binding constraint with the largest dual.
-  Lift that limit and you gain the most per unit.
-- **The closest near-miss** — the unused option with the smallest reduced cost. The first thing that
-  would enter the plan if the economics shift.
+- **Where to invest / what to renegotiate** — the binding constraint with the largest dual among
+  comparable-unit limits (or after the common-scale conversion above). Lift that limit and you gain
+  the most per unit.
+- **The closest near-miss** — the unused option with the smallest reduced cost, compared in like
+  units or as a fraction of its own coefficient. The first thing that would enter the plan if the
+  economics shift.
 
 Report both in decision language, not raw numbers: "the *RES2 machine-hour cap* is the binding
 bottleneck — each extra hour is worth ~`X` finished units; *material Y* is the closest unused option,
@@ -91,17 +96,19 @@ convergence tolerance, with no basis behind them. Those duals get the same treat
 direction, not exact rates, and at-bound reduced costs are not the crisp zero / nonzero split a
 simplex basis gives.
 
-- Report the **ranking** of binding constraints as solid; present a single dual as a *direction*
-  ("this is the lever to renegotiate"), not a hard per-unit rate.
+- Report the **ranking** of binding constraints (within comparable units) as solid; present a
+  single dual as a *direction* ("this is the lever to renegotiate"), not a hard per-unit rate.
 - Confirm any rate you quote with the one-unit re-solve (below): if the objective change does not
   match `DualValue`, the optimum is degenerate — give the direction, not the number.
 
-An LP / simplex effect; a strictly convex QP (quadratic _objective_, not constraint) has unique
-duals, so its read stays firm.
+An LP / simplex effect; a strictly convex QP (quadratic _objective_, not constraint) has a unique
+optimum and its duals read firmer — though degenerate active constraints can still make the
+multipliers non-unique, so the re-solve check stays worthwhile.
 
 ## Sign conventions
 
 `DualValue` / `ReducedCost` signs depend on the constraint sense and the objective direction. Read
 the **magnitude** for leverage ("how much per unit") and the **constraint sense** for direction
 (relaxing a `<=` capacity raises a maximize objective). When unsure, confirm with a one-unit
-re-solve: on an LP / QP the objective difference matches the dual to solver tolerance.
+re-solve: at a non-degenerate optimum the objective difference matches the dual to solver
+tolerance (when it does not, see *When a dual is soft*).

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -68,6 +68,21 @@ Report both in decision language, not raw numbers: "the *RES2 machine-hour cap* 
 bottleneck — each extra hour is worth ~`X` finished units; *material Y* is the closest unused option,
 ~`Z` away from being worth procuring."
 
+## When a dual is soft (degeneracy)
+
+A dual is exact for the basis the solver returned, but at a **degenerate** optimum — many
+constraints binding at once (a lot of `Slack ≈ 0`) — that basis is one of several, so the dual is
+one-sided and non-unique. It reads most precise exactly where it is least reliable, the common case
+on large LPs.
+
+- Report the **ranking** of binding constraints as solid; present a single dual as a *direction*
+  ("this is the lever to renegotiate"), not a hard per-unit rate.
+- Confirm any rate you quote with the one-unit re-solve (below): if the objective change does not
+  match `DualValue`, the optimum is degenerate — give the direction, not the number.
+
+An LP / simplex effect; a strictly convex QP (quadratic _objective_, not constraint) has unique
+duals, so its read stays firm.
+
 ## Sign conventions
 
 `DualValue` / `ReducedCost` signs depend on the constraint sense and the objective direction. Read

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -30,8 +30,9 @@ finite relaxation, difference two solves.
 - **Rank the binding constraints by `|DualValue|`** → a shortlist of the highest-leverage limits to
   renegotiate. Treat it as a shortlist, not a verdict: under degeneracy the dual solution itself is
   non-unique, so even the ordering can shift between equally optimal solves — confirm the top
-  lever with a differencing re-solve (see *When a dual is soft*). One catch: a dual is objective-units **per unit of
-  that constraint**, so the raw ranking only makes sense across constraints in **comparable units**
+  lever with a differencing re-solve (see *When a dual is soft*). One catch: a dual is
+  objective-units **per unit of that constraint**, so the raw ranking only makes sense across
+  constraints in **comparable units**
   (hours vs hours). To rank a machine-hour cap against a material-tonnage limit, put them on a
   common scale first — e.g. multiply each dual by a realistic relaxation step, or compare the value
   of a 1% relaxation (`|DualValue| × 0.01 × |RHS|`).
@@ -66,8 +67,8 @@ It is the **near-miss** signal.
   it with no coefficient change at all (the mirror of a binding constraint with a zero dual).
 - Among the variables left at `0` with a clearly nonzero reduced cost, the one with the
   **smallest `|ReducedCost|`** is closest to becoming worthwhile — the option to watch if a cost
-  or yield shifts slightly. Same units catch as
-  the dual ranking: a reduced cost is objective-units per unit of *that variable*, so sort only
+  or yield shifts slightly. Same units catch as the dual ranking: a reduced cost is
+  objective-units per unit of *that variable*, so sort only
   variables in comparable units against each other — or compare each `|ReducedCost|` as a fraction
   of its own objective coefficient ("needs a 3% price move" vs "needs a 40% one").
 

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -50,12 +50,16 @@ pays off as it relaxes. Hour-caps rank against hour-caps and supply limits again
 across the two, convert to a common scale first. (The model itself is a MILP, so read this from the LP relaxation
 as a guide and difference two MILP solves for the real number.)
 
-## Reduced cost — how far an unused option is from entering
+## Reduced cost — how far an unused option is from being worth using
 
-A variable resting at a bound (often `0`) carries a `ReducedCost`: how much its objective
-coefficient must improve before it could enter the optimal solution. It is the **near-miss** signal.
+A variable resting at a bound (often `0`) carries a `ReducedCost`: improve its objective
+coefficient by more than `|ReducedCost|` and the current plan stops being optimal — using that
+variable starts to pay off; by less, and leaving it at its bound stays optimal. It is the
+**near-miss** signal.
 
 - A variable with `Value > 0` is already in the mix; its reduced cost is ~0.
+- A variable **at its bound** can also price to ~0 — degeneracy again: an alternative optimum uses
+  it with no coefficient change at all (the mirror of a binding constraint with a zero dual).
 - Among the variables left at `0`, the one with the **smallest `|ReducedCost|`** is closest to
   becoming worthwhile — the option to watch if a cost or yield shifts slightly. Same units catch as
   the dual ranking: a reduced cost is objective-units per unit of *that variable*, so sort only
@@ -63,12 +67,13 @@ coefficient must improve before it could enter the optimal solution. It is the *
   of its own objective coefficient ("needs a 3% price move" vs "needs a 40% one").
 
 ```python
-# Unused options ranked by how close they are to entering (LP / QP only).
+# Unused options ranked by how close they are to paying off (LP / QP only).
 # Compare |reduced cost| within comparable-unit variables:
-near = [(v.VariableName, v.ReducedCost) for v in problem.getVariables()
-        if abs(v.Value) < 1e-6 and abs(v.ReducedCost) > 1e-9]
+near = [(v.VariableName, v.ReducedCost) for v in problem.getVariables() if abs(v.Value) < 1e-6]
 for name, rc in sorted(near, key=lambda kv: abs(kv[1])):
-    print(f"{name}: reduced cost {rc:+.4g}  (~{abs(rc):.4g} coefficient improvement before it could enter)")
+    note = ("already interchangeable — degenerate" if abs(rc) < 1e-9
+            else f"~{abs(rc):.4g} coefficient improvement before it pays off")
+    print(f"{name}: reduced cost {rc:+.4g}  ({note})")
 ```
 
 ## The decision read

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -10,16 +10,18 @@ closest near-miss."
 > (MILP)** — **including the max-supply model** — has no usable duals, and a **quadratic
 > _constraint_** makes cuOpt NaN-fill every dual (a quadratic _objective_ is fine — it is a
 > quadratic _constraint_ that breaks them). `DualValue` / `ReducedCost` are not meaningful in
-> either case. For a MILP, get the marginal value by **differencing adjacent solves** (re-solve
+> either case. For a MILP, get the value of one more unit by **differencing adjacent solves** (re-solve
 > with the bound relaxed by one unit and compare objectives), or read duals from the **LP
 > relaxation**.
 
 ## Constraint dual value — the marginal value of relaxing a limit
 
 A constraint's `DualValue` is the **sensitivity** of the optimum to that constraint: the marginal
-value of one more unit of that limit, holding everything else fixed. At a non-degenerate optimum
-that is the exact change in objective per unit relaxed; under **degeneracy** (common in practice) it
-is one-sided, so read it as a direction (see *When a dual is soft*).
+rate at which the objective improves as that limit relaxes, holding everything else fixed. It is a
+derivative, not a per-unit forecast — over a finite step (even one unit) the solution can
+restructure and the rate change along the way, and under **degeneracy** (common in practice) the
+rate is one-sided, so read it as a direction (see *When a dual is soft*). For the actual value of a
+finite relaxation, difference two solves.
 
 - The implication runs **one way**: a **slack** constraint (`Slack > 0`) always prices to ~0 —
   relaxing it changes nothing, because it is not the bottleneck. But `Slack ≈ 0` does **not**
@@ -38,7 +40,7 @@ is one-sided, so read it as a direction (see *When a dual is soft*).
 # The |dual| ranking is meaningful within comparable-unit constraints:
 binding = [(c.ConstraintName, c.DualValue) for c in problem.getConstraints() if abs(c.Slack) < 1e-6]
 for name, dual in sorted(binding, key=lambda kv: -abs(kv[1])):
-    print(f"{name}: dual {dual:+.4g}  (objective change per unit relaxed)")
+    print(f"{name}: dual {dual:+.4g}  (marginal rate as this limit relaxes)")
 ```
 
 In the max-supply shape the constraints that typically bind are the **resource-hour capacities**
@@ -73,8 +75,8 @@ for name, rc in sorted(near, key=lambda kv: abs(kv[1])):
 Two questions answered straight from the duals:
 
 - **Where to invest / what to renegotiate** — the binding constraint with the largest dual among
-  comparable-unit limits (or after the common-scale conversion above). Lift that limit and you gain
-  the most per unit.
+  comparable-unit limits (or after the common-scale conversion above). Relaxing that limit improves the
+  objective at the highest marginal rate.
 - **The closest near-miss** — the unused option with the smallest reduced cost, compared in like
   units or as a fraction of its own coefficient. The first thing that would enter the plan if the
   economics shift.
@@ -98,17 +100,15 @@ simplex basis gives.
 
 - Report the **ranking** of binding constraints (within comparable units) as solid; present a
   single dual as a *direction* ("this is the lever to renegotiate"), not a hard per-unit rate.
-- Confirm any rate you quote with the one-unit re-solve (below): if the objective change does not
-  match `DualValue`, the optimum is degenerate — give the direction, not the number.
+- Quote a finite change only from a differencing re-solve: the dual is the rate at the current
+  optimum, and the realized change over a step can differ from `dual × step` (the active set can
+  change along the way, degenerate or not).
 
-An LP / simplex effect; a strictly convex QP (quadratic _objective_, not constraint) has a unique
-optimum and its duals read firmer — though degenerate active constraints can still make the
-multipliers non-unique, so the re-solve check stays worthwhile.
 
 ## Sign conventions
 
 `DualValue` / `ReducedCost` signs depend on the constraint sense and the objective direction. Read
 the **magnitude** for leverage ("how much per unit") and the **constraint sense** for direction
-(relaxing a `<=` capacity raises a maximize objective). When unsure, confirm with a one-unit
-re-solve: at a non-degenerate optimum the objective difference matches the dual to solver
-tolerance (when it does not, see *When a dual is soft*).
+(relaxing a `<=` capacity raises a maximize objective). When unsure, re-solve with the bound
+slightly relaxed: the sign of the objective change gives the direction, and the difference itself
+is the number to quote for a finite step (see *When a dual is soft*).

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -1,0 +1,72 @@
+# Interpreting Duals: Shadow Prices, Reduced Costs, and Slack
+
+`diagnostic_snippets.md` shows how to *read* `DualValue`, `ReducedCost`, and `Slack` off a solved
+problem. This explains what they *mean* for the decision — turning solver output into "which
+constraint is the binding bottleneck, what relaxing it is worth, and which unused option is the
+closest near-miss."
+
+> **LP / QP only.** Duals and reduced costs exist for **continuous** (LP / QP) solutions. An
+> integer model (MILP) — **including the max-supply model** — returns no usable duals;
+> `DualValue` / `ReducedCost` are not meaningful there. For a MILP, get the marginal value by
+> **differencing adjacent solves** (re-solve with the bound relaxed by one unit and compare
+> objectives), or read duals from the **LP relaxation**.
+
+## Shadow price — the value of relaxing a constraint
+
+A constraint's `DualValue` is its **shadow price**: the change in the optimal objective per unit
+relaxation of that constraint's right-hand side, holding everything else fixed.
+
+- A **binding** constraint (`Slack ≈ 0`) carries a nonzero shadow price — it is actively limiting
+  the objective. A **slack** constraint (`Slack > 0`) has a shadow price of ~0: relaxing it changes
+  nothing, because it is not the bottleneck.
+- **Rank the binding constraints by `|DualValue|`** → the largest is the highest-leverage limit to
+  renegotiate: "relax this by one unit and the objective improves by `DualValue`."
+
+```python
+# Which constraints bind, and what each is worth (LP / QP only):
+binding = [(c.ConstraintName, c.DualValue) for c in problem.getConstraints() if abs(c.Slack) < 1e-6]
+for name, dual in sorted(binding, key=lambda kv: -abs(kv[1])):
+    print(f"{name}: shadow price {dual:+.4g}  (objective change per unit relaxed)")
+```
+
+In the max-supply shape the constraints that typically bind are the **resource-hour capacities**
+and the **per-period supply limits** — the shadow price tells you which machine-hour (e.g. a tight
+`RES2` period) or which material is the binding bottleneck, and what one more hour or unit of supply
+is worth in finished-goods terms. (Read it from the LP relaxation, since the model itself is a MILP.)
+
+## Reduced cost — how far an unused option is from entering
+
+A variable resting at a bound (often `0`) carries a `ReducedCost`: how much its objective
+coefficient must improve before it would enter the optimal solution. It is the **near-miss** signal.
+
+- A variable with `Value > 0` is already in the mix; its reduced cost is ~0.
+- Among the variables left at `0`, the one with the **smallest `|ReducedCost|`** is closest to
+  becoming worthwhile — the option to watch if a cost or yield shifts slightly.
+
+```python
+# Unused options ranked by how close they are to entering (LP / QP only):
+near = [(v.VariableName, v.ReducedCost) for v in problem.getVariables()
+        if abs(v.Value) < 1e-6 and abs(v.ReducedCost) > 1e-9]
+for name, rc in sorted(near, key=lambda kv: abs(kv[1])):
+    print(f"{name}: reduced cost {rc:+.4g}  (improve its coefficient by ~{abs(rc):.4g} to use it)")
+```
+
+## The decision read
+
+Two questions answered straight from the duals:
+
+- **Where to invest / what to renegotiate** — the binding constraint with the largest shadow price.
+  Lift that limit and you gain the most per unit.
+- **The closest near-miss** — the unused option with the smallest reduced cost. The first thing that
+  would enter the plan if the economics shift.
+
+Report both in decision language, not raw numbers: "the *RES2 machine-hour cap* is the binding
+bottleneck — each extra hour is worth ~`X` finished units; *material Y* is the closest unused option,
+~`Z` away from being worth procuring."
+
+## Sign conventions
+
+`DualValue` / `ReducedCost` signs depend on the constraint sense and the objective direction. Read
+the **magnitude** for leverage ("how much per unit") and the **constraint sense** for direction
+(relaxing a `<=` capacity raises a maximize objective). When unsure, confirm with a one-unit
+re-solve: on an LP / QP the objective difference matches the dual to solver tolerance.

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -21,12 +21,17 @@ value of one more unit of that limit, holding everything else fixed. At a non-de
 that is the exact change in objective per unit relaxed; under **degeneracy** (common in practice) it
 is one-sided, so read it as a direction (see *When a dual is soft*).
 
-- A **binding** constraint (`Slack ≈ 0`) carries a nonzero dual — it is actively limiting
-  the objective. A **slack** constraint (`Slack > 0`) prices to ~0: relaxing it changes
-  nothing, because it is not the bottleneck.
+- The implication runs **one way**: a **slack** constraint (`Slack > 0`) always prices to ~0 —
+  relaxing it changes nothing, because it is not the bottleneck. But `Slack ≈ 0` does **not**
+  guarantee a nonzero dual: a binding constraint can still price to 0 (a form of degeneracy — see
+  *When a dual is soft*). A nonzero dual means binding; binding does not mean a nonzero dual.
 - **Rank the binding constraints by `|DualValue|`** → the largest is the highest-leverage limit to
   renegotiate. The *ranking* is the robust read; a single dual is a direction, not a guaranteed
-  per-unit rate (see *When a dual is soft*).
+  per-unit rate (see *When a dual is soft*). One catch: a dual is objective-units **per unit of
+  that constraint**, so the raw ranking only makes sense across constraints in **comparable units**
+  (hours vs hours). To rank a machine-hour cap against a material-tonnage limit, put them on a
+  common scale first — e.g. multiply each dual by a realistic relaxation step, or compare the value
+  of a 1% relaxation (`|DualValue| × 0.01 × |RHS|`).
 
 ```python
 # Which constraints bind, and what each is worth (LP / QP only):
@@ -47,7 +52,10 @@ coefficient must improve before it would enter the optimal solution. It is the *
 
 - A variable with `Value > 0` is already in the mix; its reduced cost is ~0.
 - Among the variables left at `0`, the one with the **smallest `|ReducedCost|`** is closest to
-  becoming worthwhile — the option to watch if a cost or yield shifts slightly.
+  becoming worthwhile — the option to watch if a cost or yield shifts slightly. Same units catch as
+  the dual ranking: a reduced cost is objective-units per unit of *that variable*, so sort only
+  variables in comparable units against each other — or compare each `|ReducedCost|` as a fraction
+  of its own objective coefficient ("needs a 3% price move" vs "needs a 40% one").
 
 ```python
 # Unused options ranked by how close they are to entering (LP / QP only):
@@ -76,6 +84,12 @@ A dual is exact for the basis the solver returned, but at a **degenerate** optim
 constraints binding at once (a lot of `Slack ≈ 0`) — that basis is one of several, so the dual is
 one-sided and non-unique. It reads most precise exactly where it is least reliable, the common case
 on large LPs.
+
+Which solver ran matters too: cuOpt **often returns no basis at all** — the first-order **PDLP**
+path (common on large LPs, and one arm of the concurrent default) produces duals only to the
+convergence tolerance, with no basis behind them. Those duals get the same treatment: leverage and
+direction, not exact rates, and at-bound reduced costs are not the crisp zero / nonzero split a
+simplex basis gives.
 
 - Report the **ranking** of binding constraints as solid; present a single dual as a *direction*
   ("this is the lever to renegotiate"), not a hard per-unit rate.

--- a/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
+++ b/cuopt-agent/skills/max-supply/cuopt-debugging/resources/interpreting_duals.md
@@ -11,8 +11,8 @@ closest near-miss."
 > _constraint_** makes cuOpt NaN-fill every dual (a quadratic _objective_ is fine — it is a
 > quadratic _constraint_ that breaks them). `DualValue` / `ReducedCost` are not meaningful in
 > either case. For a MILP, get the value of one more unit by **differencing adjacent solves** (re-solve
-> with the bound relaxed by one unit and compare objectives), or read duals from the **LP
-> relaxation**.
+> with the bound relaxed by one unit and compare objectives); duals of the **LP relaxation** are a
+> quicker guide, but the integer optimum can respond differently — differencing is the ground truth.
 
 ## Constraint dual value — the marginal value of relaxing a limit
 
@@ -46,8 +46,9 @@ for name, dual in sorted(binding, key=lambda kv: -abs(kv[1])):
 In the max-supply shape the constraints that typically bind are the **resource-hour capacities**
 and the **per-period supply limits** — the dual prices each one: the marginal rate, in
 finished-goods terms, at which a tight resource period (e.g. `RES2`) or a material's supply limit
-pays off as it relaxes. Hour-caps rank against hour-caps and supply limits against supply limits; across the two,
-convert to a common scale first. (Read it from the LP relaxation, since the model itself is a MILP.)
+pays off as it relaxes. Hour-caps rank against hour-caps and supply limits against supply limits;
+across the two, convert to a common scale first. (The model itself is a MILP, so read this from the LP relaxation
+as a guide and difference two MILP solves for the real number.)
 
 ## Reduced cost — how far an unused option is from entering
 


### PR DESCRIPTION
## What

Adds `resources/interpreting_duals.md` to the cuopt-agent's `cuopt-debugging` skill: guidance for turning a solved LP/QP's `DualValue` / `ReducedCost` / `Slack` into a **decision read** — which constraint is the binding bottleneck and what relaxing it is worth (its dual value), and which unused option is the closest near-miss (reduced cost) — with the one-way implications and degeneracy / no-basis caveats that keep those reads honest (rankings as shortlists; any quoted number confirmed by a differencing re-solve). Linked from the skill's `SKILL.md`.

## Why

The skill already shows how to *read* duals (`diagnostic_snippets.md`) but not what they *mean* for the decision. It also makes the scope explicit — consistent with the main-repo dual/sensitivity work (**NVIDIA/cuopt#1393**, **#1406**): duals exist for **continuous (LP/QP)** solves off **linear** constraints. Two cases return none — an integer model (the max-supply model is a MILP) and a quadratic *constraint* (a quadratic *objective* is fine) — with the difference-adjacent-solves / LP-relaxation fallback called out for the MILP.

## Notes

- Pure guidance — a skill `resources/` markdown plus a one-line `SKILL.md` pointer; no code or model changes.
- Grounded in the max-supply shape (resource-hour caps and per-period supply limits as the binding bottlenecks).

Companion to the dual / sensitivity work in **NVIDIA/cuopt-examples#154** (LP duals in the diet example) and **#157** (the agent's multi-objective scenario).
