### PR TITLE
ci: skip AI-accelerated-routing notebooks in CI

### DIFF
--- a/AI-accelerated-routing/initializing_cuopt_with_rl_solutions.ipynb
+++ b/AI-accelerated-routing/initializing_cuopt_with_rl_solutions.ipynb
@@ -34,6 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Skip notebook test\n",
     "# Verify Python>=3.10\n",
     "import sys\n",
     "print(sys.version)"

--- a/AI-accelerated-routing/training_rl_agent_for_vrp.ipynb
+++ b/AI-accelerated-routing/training_rl_agent_for_vrp.ipynb
@@ -34,6 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Skip notebook test\n",
     "# Verify Python>=3.10\n",
     "import sys\n",
     "print(sys.version)"


### PR DESCRIPTION
Both notebooks require EARLI (installed from GitHub), wandb auth, and long-running RL training — not suitable for automated CI.