### PR TITLE
fix: guard non-string JSON type fields before strcmp in C API driver

### DIFF
--- a/benchmark_apis/c_api_driver/cuopt_json_to_c_api.c
+++ b/benchmark_apis/c_api_driver/cuopt_json_to_c_api.c
@@ -361,15 +361,15 @@ int parse_cuopt_json(const char* filename, ProblemData* data) {
                 cJSON* type_item = types->child;
                 while (bound_item && type_item && i < data->num_constraints) {
                     cuopt_float_t bound_value = parse_numeric_value(bound_item);
-                    char* type = type_item->valuestring;
-                    
-                    if (strcmp(type, "L") == 0) {  // Less than or equal
+                    char* type = cJSON_IsString(type_item) ? type_item->valuestring : NULL;
+
+                    if (type && strcmp(type, "L") == 0) {  // Less than or equal
                         data->constraint_lower_bounds[i] = -CUOPT_INFINITY;
                         data->constraint_upper_bounds[i] = bound_value;
-                    } else if (strcmp(type, "G") == 0) {  // Greater than or equal
+                    } else if (type && strcmp(type, "G") == 0) {  // Greater than or equal
                         data->constraint_lower_bounds[i] = bound_value;
                         data->constraint_upper_bounds[i] = CUOPT_INFINITY;
-                    } else if (strcmp(type, "E") == 0) {  // Equal
+                    } else if (type && strcmp(type, "E") == 0) {  // Equal
                         data->constraint_lower_bounds[i] = bound_value;
                         data->constraint_upper_bounds[i] = bound_value;
                     }
@@ -431,8 +431,8 @@ int parse_cuopt_json(const char* filename, ProblemData* data) {
         i = 0;
         cJSON* type_item;
         cJSON_ArrayForEach(type_item, variable_types) {
-            char* type_str = type_item->valuestring;
-            if (strcmp(type_str, "I") == 0) {
+            char* type_str = cJSON_IsString(type_item) ? type_item->valuestring : NULL;
+            if (type_str && strcmp(type_str, "I") == 0) {
                 data->variable_types[i] = CUOPT_INTEGER;
             } else {
                 data->variable_types[i] = CUOPT_CONTINUOUS;


### PR DESCRIPTION
## Summary
`parse_cuopt_json()` in `benchmark_apis/c_api_driver/cuopt_json_to_c_api.c` read JSON array
elements via cJSON's `valuestring` and passed them straight to `strcmp()`. cJSON sets
`valuestring` to `NULL` for non-string nodes (numbers, bools, `null`, arrays, objects), so a
non-string element produced `strcmp(NULL, ...)` — a NULL-pointer dereference that crashes the
driver (SIGSEGV; UBSan nonnull violation) on untrusted cuOpt-JSON input.

Two sinks were affected:
- `variable_types[]` parsing loop (`strcmp(type_str, "I")`)
- `constraint_bounds.types[]` fallback (`strcmp(type, "L"|"G"|"E")`)

## Fix
Guard both sinks with `cJSON_IsString()` + a `NULL` check before each `strcmp`, falling back to
the existing default (CONTINUOUS variable / unconstrained row) for non-string entries. This
matches the `cJSON_IsString(...) ? ... : NULL` pattern already used in `parse_numeric_value()`.

## Reproducer
```json
{
  "csr_constraint_matrix": {"offsets": [0, 1], "indices": [0], "values": [1.0]},
  "objective_data": {"coefficients": [1.0], "offset": 0.0},
  "variable_bounds": {"lower_bounds": [0.0], "upper_bounds": [0.0]},
  "maximize": false,
  "variable_types": [123]
}
```
A non-string `constraint_bounds.types` element (e.g. `"types": [123]`) triggers the same crash
on the `G`/`E` branches.

## Verification
Built the translation unit under ASan + UBSan (real parser, stubbed solver). Both a
number-valued `variable_types` element and a number-valued `constraint_bounds.types` element
**crashed with a SEGV in `strcmp` before the fix** and **parse cleanly after**.

Found via fuzzing; robustness / availability hardening (not a production solver path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)