### PR TITLE
fix(notebooks): relax scipy==1.15.2 pin to >=1.15.2 for Python 3.14 compat

### DIFF
--- a/portfolio_optimization/cvar_portfolio_optimization.ipynb
+++ b/portfolio_optimization/cvar_portfolio_optimization.ipynb
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --extra-index-url https://pypi.nvidia.com \"numpy>=1.24.4\" \"pandas>=2.2.1\" \"scipy==1.15.2\" \"seaborn>=0.13.2\""
+    "!pip install --extra-index-url https://pypi.nvidia.com \"numpy>=1.24.4\" \"pandas>=2.2.1\" \"scipy>=1.15.2\" \"seaborn>=0.13.2\""
    ]
   },
   {


### PR DESCRIPTION
## Summary

- `portfolio_optimization/cvar_portfolio_optimization.ipynb` was failing in CI ([job 84392333408](https://github.com/NVIDIA/cuopt/actions/runs/28426561531/job/84392333408)) on the Python 3.14 matrix entry
- Root cause: `scipy==1.15.2` has no pre-built wheel for Python 3.14. pip falls back to building from source, which fails because the test container has no C compiler (`cc`, `gcc`, `clang` all missing)
- The notebook solver itself ran fine — only the pre-flight `!pip install` cell failed
- Fix: relax `scipy==1.15.2` → `scipy>=1.15.2` so pip can select a wheel-compatible version for Python 3.14
- Audited all other notebooks: no other notebook hard-pins scipy with `==`

## Test plan

- [ ] `conda-notebook-tests` CI job passes on Python 3.14 matrix entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)