### PR TITLE
fix(notebooks): fix GAMSPy intro cell type from code to markdown

### DIFF
--- a/GAMSPy_integration_example/transport_cuopt.ipynb
+++ b/GAMSPy_integration_example/transport_cuopt.ipynb
@@ -1,955 +1,953 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:15.883029Z",
-          "iopub.status.busy": "2025-07-17T10:21:15.882854Z",
-          "iopub.status.idle": "2025-07-17T10:21:40.914508Z",
-          "shell.execute_reply": "2025-07-17T10:21:40.914244Z"
-        },
-        "vscode": {
-          "languageId": "shellscript"
-        }
-      },
-      "source": [
-        "# GAMSPy model example\n",
-        "\n",
-        "## Introduction\n",
-        "\n",
-        "This quick start guide is designed to provide you with a concise overview of GAMSPy and its key features. By the end of this guide, you'll have a solid understanding of how to create basic mathematical models using GAMSPy. For more advanced features, we recommend exploring our comprehensive [user guide](https://gamspy.readthedocs.io/en/latest/user/index.html) and the extensive [model library](https://gamspy.readthedocs.io/en/latest/user/model_library.html).\n",
-        "\n",
-        "While not mandatory, having a basic understanding of Python programming and familiarity with the [Pandas library](https://pandas.pydata.org/). will be helpful in following this tutorial.\n",
-        "\n",
-        "## A Transportation Problem\n",
-        "\n",
-        "In this guide, we'll delve into an example of the transportation problem. This classic scenario involves managing supplies from various plants to meet demands at multiple markets for a single commodity. Additionally, we have the unit costs associated with shipping the commodity from plants to markets. The fundamental economic question here is: \n",
-        "\n",
-        "> How can we optimize the shipment quantities between each plant and market to minimize the total transport cost?\n",
-        "\n",
-        "The problem's algebraic representation typically takes the following format:\n",
-        "\n",
-        "Indices (Sets):\n",
-        "\n",
-        "- $i$ = plants\n",
-        "- $j$ = markets\n",
-        "\n",
-        "Given Data (Parameters):\n",
-        "\n",
-        "- $a_i$ = supply of commodity at plant $i$ (in cases)\n",
-        "- $b_j$ = demand for commodity at market $j$ (in cases)\n",
-        "- $c_{ij}$ = cost per unit of shipment between plant $i$ and market $j$\n",
-        "\n",
-        "Decision Variables:\n",
-        "\n",
-        "- $x_{ij}$ = amount of commodity to ship from plant $i$ to market $j$ where $x_{ij} \\ge 0$ for all $i,j$\n",
-        "\n",
-        "Constraints:\n",
-        "\n",
-        "- Observe supply limit at plant $i$: $\\sum_j x_{ij} \\le a_i \\: \\forall i$\n",
-        "- Satisfy demand at market $j$: $\\sum_i x_{ij} \\ge b_j \\: \\forall j$\n",
-        "- Objective Function: Minimize $\\sum_i \\sum_j c_{ij} \\cdot x_{ij}$"
-      ],
-      "execution_count": null,
-      "outputs": []
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:15.883029Z",
+     "iopub.status.busy": "2025-07-17T10:21:15.882854Z",
+     "iopub.status.idle": "2025-07-17T10:21:40.914508Z",
+     "shell.execute_reply": "2025-07-17T10:21:40.914244Z"
     },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "import subprocess\n",
-        "import html\n",
-        "from IPython.display import display, HTML\n",
-        "\n",
-        "def check_gpu():\n",
-        "    try:\n",
-        "        result = subprocess.run([\"nvidia-smi\"], capture_output=True, text=True, timeout=5)\n",
-        "        result.check_returncode()\n",
-        "        lines = result.stdout.splitlines()\n",
-        "        gpu_info = lines[2] if len(lines) > 2 else \"GPU detected\"\n",
-        "        gpu_info_escaped = html.escape(gpu_info)\n",
-        "        display(HTML(f\"\"\"\n",
-        "        <div style=\"border:2px solid #4CAF50;padding:10px;border-radius:10px;background:#e8f5e9;\">\n",
-        "            <h3>✅ GPU is enabled</h3>\n",
-        "            <pre>{gpu_info_escaped}</pre>\n",
-        "        </div>\n",
-        "        \"\"\"))\n",
-        "        return True\n",
-        "    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError, IndexError) as e:\n",
-        "        display(HTML(\"\"\"\n",
-        "        <div style=\"border:2px solid red;padding:15px;border-radius:10px;background:#ffeeee;\">\n",
-        "            <h3>⚠️ GPU not detected!</h3>\n",
-        "            <p>This notebook requires a <b>GPU runtime</b>.</p>\n",
-        "            \n",
-        "            <h4>If running in Google Colab:</h4>\n",
-        "            <ol>\n",
-        "              <li>Click on <b>Runtime → Change runtime type</b></li>\n",
-        "              <li>Set <b>Hardware accelerator</b> to <b>GPU</b></li>\n",
-        "              <li>Then click <b>Save</b> and <b>Runtime → Restart runtime</b>.</li>\n",
-        "            </ol>\n",
-        "            \n",
-        "            <h4>If running in Docker:</h4>\n",
-        "            <ol>\n",
-        "              <li>Ensure you have <b>NVIDIA Docker runtime</b> installed (<code>nvidia-docker2</code>)</li>\n",
-        "              <li>Run container with GPU support: <code>docker run --gpus all ...</code></li>\n",
-        "              <li>Or use: <code>docker run --runtime=nvidia ...</code> for older Docker versions</li>\n",
-        "              <li>Verify GPU access: <code>docker run --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi</code></li>\n",
-        "            </ol>\n",
-        "            \n",
-        "            <p><b>Additional resources:</b></p>\n",
-        "            <ul>\n",
-        "              <li><a href=\"https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html\" target=\"_blank\">NVIDIA Container Toolkit Installation Guide</a></li>\n",
-        "            </ul>\n",
-        "        </div>\n",
-        "        \"\"\"))\n",
-        "        return False\n",
-        "\n",
-        "check_gpu()"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
-        "#!pip uninstall -y cuda-python cuda-bindings cuda-core\n",
-        "#!pip install --upgrade --extra-index-url=https://pypi.nvidia.com cuopt-cu12 nvidia-nvjitlink-cu12 rapids-logger==0.1.19\n",
-        "#!pip install --upgrade --extra-index-url=https://pypi.nvidia.com cuopt-cu13 nvidia-nvjitlink-cu13 rapids-logger==0.1.1"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "# Install other dependencies (if not already installed)\n",
-        "\n",
-        "!pip install -q gamspy\n",
-        "import subprocess\n",
-        "import sys\n",
-        "# Change the zip URL below depending on your target CUDA version and architecture (x86_64 or aarch64).\n",
-        "# See https://github.com/GAMS-dev/cuoptlink-builder/releases for available builds.\n",
-        "!wget -nc -nv -O cuopt-link-release.zip \"https://github.com/GAMS-dev/cuoptlink-builder/releases/download/v0.0.5e/cuopt-link-release-cu13-x86_64.zip\"\n",
-        "gams_base_path = subprocess.check_output([sys.executable, '-m', 'gamspy', 'show', 'base']).decode('utf-8').strip()\n",
-        "subprocess.run(f\"unzip -o cuopt-link-release.zip -d {gams_base_path}\", shell=True, check=True)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Data\n",
-        "\n",
-        "Before we dive into the optimization process, let's handle our data using the [Pandas library](https://pandas.pydata.org/). We'll begin by organizing the necessary information, which we will subsequently feed into our optimization model."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:40.915536Z",
-          "iopub.status.busy": "2025-07-17T10:21:40.915457Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.083438Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.083230Z"
-        }
-      },
-      "source": [
-        "import pandas as pd\n",
-        "\n",
-        "capacities = pd.DataFrame(\n",
-        "    [[\"seattle\", 350], [\"san-diego\", 600]], columns=[\"city\", \"capacity\"]\n",
-        ").set_index(\"city\")\n",
-        "\n",
-        "capacities"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.084284Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.084168Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.086987Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.086797Z"
-        }
-      },
-      "source": [
-        "demands = pd.DataFrame(\n",
-        "    [[\"new-york\", 325], [\"chicago\", 300], [\"topeka\", 275]], columns=[\"city\", \"demand\"]\n",
-        ").set_index(\"city\")\n",
-        "\n",
-        "demands"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.087770Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.087633Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.091517Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.091358Z"
-        }
-      },
-      "source": [
-        "distances = pd.DataFrame(\n",
-        "    [\n",
-        "        [\"seattle\", \"new-york\", 2.5],\n",
-        "        [\"seattle\", \"chicago\", 1.7],\n",
-        "        [\"seattle\", \"topeka\", 1.8],\n",
-        "        [\"san-diego\", \"new-york\", 2.5],\n",
-        "        [\"san-diego\", \"chicago\", 1.8],\n",
-        "        [\"san-diego\", \"topeka\", 1.4],\n",
-        "    ],\n",
-        "    columns=[\"from\", \"to\", \"distance\"],\n",
-        ").set_index([\"from\", \"to\"])\n",
-        "\n",
-        "distances"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.092111Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.092042Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.093337Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.093174Z"
-        }
-      },
-      "source": [
-        "freight_cost = 90"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Symbol Declaration\n",
-        "\n",
-        "In line with our systematic breakdown of the transportation problem into sets, parameters, variables, and constraints, we will adopt a similar approach to define the problem as a GAMSPy `Model`. To do so, it is essential to import the `gamspy` library initially."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.093948Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.093881Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.163655Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.163440Z"
-        }
-      },
-      "source": [
-        "from gamspy import Container, Set, Parameter, Variable, Equation, Model, Sum, Sense"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Container\n",
-        "\n",
-        "Before we proceed further, let's create a `Container` to encapsulate all the relevant information for our GAMSPy ``Model``. This ``Container`` acts as a centralized hub, gathering essential data, sets, parameters, variables, and constraints, providing a clear structure for our optimization problem."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.164784Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.164605Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.172679Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.172515Z"
-        }
-      },
-      "source": [
-        "m = Container()"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Sets\n",
-        "\n",
-        "Sets serve as the fundamental building blocks of a GAMSPy ``Model``, directly corresponding to the indices in the algebraic representations of models. In our transportation problem context, we have defined the following indices:\n",
-        "\n",
-        "- $i$ = plants\n",
-        "- $j$ = markets\n",
-        "\n",
-        "For detailed guidance on using sets, please refer to the [set section](https://gamspy.readthedocs.io/en/latest/user/basics/set.html) of our user guide.\n",
-        "\n",
-        "There a two ways to declare sets:\n",
-        "\n",
-        "1. Separate declaration and data assignment\n",
-        "2. Combine declaration and data assignment\n",
-        "\n",
-        "#### Separate declaration and data assignment\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.173454Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.173302Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.179619Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.179429Z"
-        }
-      },
-      "source": [
-        "i = Set(container=m, name=\"i\", description=\"plants\")\n",
-        "i.setRecords(capacities.index)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "#### Combine declaration and data assignment\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.180411Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.180278Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.190480Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.190323Z"
-        },
-        "tags": []
-      },
-      "source": [
-        "j = Set(container=m, name=\"j\", description=\"markets\", records=demands.index)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "The effect of using the above `Set` statements is that we declared two sets, namely $i$ and $j$. Additionally, we provided descriptions to elaborate on their meaning, enhancing the readability of our ``Model``. Lastly, we assigned members to the sets, establishing a clear connection between the abstract sets and their real-world counterparts.\n",
-        "\n",
-        "$i$ = {Seattle, San Diego}\n",
-        "\n",
-        "$j$ = {New York, Chicago, Topeka}\n",
-        "\n",
-        "To verify the content of a set, you can use `<set name>.records`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.191227Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.191108Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.193520Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.193371Z"
-        }
-      },
-      "source": [
-        "i.records"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.194209Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.194141Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.196323Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.196172Z"
-        }
-      },
-      "source": [
-        "j.records"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Parameters\n",
-        "\n",
-        "Declaring parameters involves using `Parameter`. Each parameter is assigned a name and a description.  Note that parameter $a_i$ is indexed by $i$. To accommodate these indices, we include the `domain` attribute, pointing to the corresponding set.\n",
-        "\n",
-        "It is worth mentioning that, similar to sets, you have the flexibility to either combine or separate the declaration and data assignment steps. For convenience, we will proceed by combining the declaration and data assignment.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.196997Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.196933Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.201694Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.201542Z"
-        }
-      },
-      "source": [
-        "a = Parameter(\n",
-        "    container=m, \n",
-        "    name=\"a\",\n",
-        "    domain=i,\n",
-        "    description=\"supply of commodity at plant i (in cases)\",\n",
-        "    records=capacities.reset_index(),\n",
-        ")\n",
-        "a.records"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.202335Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.202270Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.206850Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.206694Z"
-        }
-      },
-      "source": [
-        "b = Parameter(\n",
-        "    container=m,\n",
-        "    name=\"b\",\n",
-        "    domain=j,\n",
-        "    description=\"demand for commodity at market j (in cases)\",\n",
-        "    records=demands.reset_index(),\n",
-        ")\n",
-        "b.records"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.207532Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.207468Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.209778Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.209610Z"
-        }
-      },
-      "source": [
-        "c = Parameter(\n",
-        "    container=m,\n",
-        "    name=\"c\",\n",
-        "    domain=[i, j],\n",
-        "    description=\"cost per unit of shipment between plant i and market j\",\n",
-        ")"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "The cost per unit of shipment between plant $i$ and market $j$ is derived from the distance between $i$ and $j$ and can be calculated as follows:\n",
-        "\n",
-        "$c_{ij} = \\frac{90 \\cdot d_{ij}}{1000}$,\n",
-        "\n",
-        "where $d_{ij}$ denotes the distance between $i$ and $j$.\n",
-        "\n",
-        "We have two options to calculate $c_{ij}$ and assign the data to the GAMSPy parameter:\n",
-        "\n",
-        "1. Python assignment - calculation in Python, e.g., using Pandas and `<parameter name>.setRecords()`\n",
-        "2. GAMSPy assignment - calculation in GAMSPy\n",
-        "\n",
-        "#### Python Assignment"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.210541Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.210390Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.213168Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.213001Z"
-        }
-      },
-      "source": [
-        "cost = freight_cost * distances / 1000\n",
-        "cost"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.213745Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.213681Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.218945Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.218784Z"
-        }
-      },
-      "source": [
-        "c.setRecords(cost.reset_index())\n",
-        "c.records"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "#### GAMSPy Assignment\n",
-        "\n",
-        "For the direct assignment we need to declare a new ``Parameter`` denoting the distances between $i$ and $j$.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.219662Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.219599Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.225144Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.224999Z"
-        }
-      },
-      "source": [
-        "d = Parameter(\n",
-        "    container=m,\n",
-        "    name=\"d\",\n",
-        "    domain=[i, j],\n",
-        "    description=\"distance between plant i and market j\",\n",
-        "    records=distances.reset_index(),\n",
-        ")\n",
-        "d.records"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.225778Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.225715Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.230168Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.229995Z"
-        }
-      },
-      "source": [
-        "c[i, j] = freight_cost * d[i, j] / 1000\n",
-        "c.records"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Further information on the usage of parameters can be found in our [parameter section](https://gamspy.readthedocs.io/en/latest/user/basics/parameter.html) of the user guide."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Variables\n",
-        "\n",
-        "GAMSPy variables are declared using `Variable`. Each ``Variable`` is assigned a name, a domain if necessary, a type, and, optionally, a description."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.230884Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.230819Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.233170Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.233016Z"
-        }
-      },
-      "source": [
-        "x = Variable(\n",
-        "    container=m,\n",
-        "    name=\"x\",\n",
-        "    domain=[i, j],\n",
-        "    type=\"Positive\",\n",
-        "    description=\"amount of commodity to ship from plant i to market j\",\n",
-        ")"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "This statement results in the declaration of a shipment variable for each (i,j) pair.\n",
-        "\n",
-        "More information on variables can be found in the [variable section](https://gamspy.readthedocs.io/en/latest/user/basics/variable.html) of our user guide."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Equations\n",
-        "A GAMSPy ``Equation`` must be declared and defined in two separate statements. The format of the declaration is the same as for other GAMSPy symbols. First comes the keyword, `Equation` in this case, followed by the name, domain and text. The transportation problem has two constraints:\n",
-        "\n",
-        "Supply: observe supply limit at plant $i$: $\\sum_j x_{ij} \\le a_i \\: \\forall i$\n",
-        "\n",
-        "Demand: satisfy demand at market $j$: $\\sum_i x_{ij} \\ge b_j \\: \\forall j$"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.233875Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.233798Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.237181Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.237005Z"
-        }
-      },
-      "source": [
-        "supply = Equation(\n",
-        "    container=m, name=\"supply\", domain=i, description=\"observe supply limit at plant i\"\n",
-        ")\n",
-        "demand = Equation(\n",
-        "    container=m, name=\"demand\", domain=j, description=\"satisfy demand at market j\"\n",
-        ")"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "The components of an ``Equation`` definition are:\n",
-        "1. The Python variable of the ``Equation`` being defined\n",
-        "2. The domain (optional)\n",
-        "3. Domain restricting conditions (optional)\n",
-        "4. A `=` sign\n",
-        "5. Left hand side expression\n",
-        "6. Relational operator (`==`, `<=`, `>=`)\n",
-        "7. The right hand side expression.\n",
-        "\n",
-        "The ``Equation`` definition for the supply constraint of the transportation problem is implemented as follows:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.237863Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.237785Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.240437Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.240285Z"
-        }
-      },
-      "source": [
-        "supply[i] = Sum(j, x[i, j]) <= a[i]"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Using the same logic as above, we can define the demand equation as follows:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.241111Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.241033Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.243421Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.243270Z"
-        }
-      },
-      "source": [
-        "demand[j] = Sum(i, x[i, j]) >= b[j]"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "More information on equations is given in the [equation section](https://gamspy.readthedocs.io/en/latest/user/basics/equation.html) of our user guide."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Objective\n",
-        "The objective function of a GAMSPy ``Model`` does not require a separate ``Equation`` declaration. You can assign the objective expression to a Python variable or use it directly in the ``Model()`` statement of the [next section](#model).\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.244117Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.244038Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.245432Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.245247Z"
-        }
-      },
-      "source": [
-        "obj = Sum((i, j), c[i, j] * x[i, j])"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Model\n",
-        "\n",
-        "A GAMSPy `Model()` consolidates constraints, an objective function, a sense (minimize, maximize, and feasibility), and a problem type. It also possesses a name and is associated with a ``Container``.\n",
-        "\n",
-        "To define our transportation problem as a GAMSPy ``Model``, we assign it to a Python variable, link it to our ``Container`` (populated with symbols and data), name it \"transport\", specify the equations, set the problem type as linear program (LP), specify the sense of the objective function (``Sense.MIN``), and point to the objective expression.\n",
-        "\n",
-        "GAMSPy allows two alternatives to assign equations to a `Model`:\n",
-        "1. Using a list of equations,\n",
-        "2. Retrieving _all_ equations by calling `m.getEquations()`.\n",
-        "\n",
-        "### Using a List of Equations\n",
-        "Using a list of equations is especially useful if you want to define multiple GAMSPy ``Model``s with a subset of the  equations in your ``Container``. For the transportation problem this can be done as follows:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.246093Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.246032Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.248358Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.248217Z"
-        }
-      },
-      "source": [
-        "transport = Model(\n",
-        "    m,\n",
-        "    name=\"transport\",\n",
-        "    equations=[supply, demand],\n",
-        "    problem=\"LP\",\n",
-        "    sense=Sense.MIN,\n",
-        "    objective=obj,\n",
-        ")"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Retrieving all Equations\n",
-        "Using `m.getEquations()` is especially convenient if you want to include all equations of your ``Container`` to be associated with your model. For the transportation problem this can be done as follows:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.248970Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.248907Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.251180Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.251016Z"
-        }
-      },
-      "source": [
-        "transport_2 = Model(\n",
-        "    m,\n",
-        "    name=\"transport2\",\n",
-        "    equations=m.getEquations(),\n",
-        "    problem=\"LP\",\n",
-        "    sense=Sense.MIN,\n",
-        "    objective=obj,\n",
-        ")"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "More information on the usage of a GAMSPy `Model` can be found in the [model section](https://gamspy.readthedocs.io/en/latest/user/basics/model.html) of our user guide."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Solve\n",
-        "\n",
-        "Upon defining the GAMSPy ``Model``, it's ready for being solved. The ``solve()`` statement triggers the generation of the specific model instance, creates suitable data structures for the solver, and invokes the solver. To view solver output in the console, the ``sys`` library can be used, passing the ``output=sys.stdout`` attribute to ``transport.solve()``.\n",
-        "\n",
-        "**Note**: The following cell contains the two most important pieces to get a GAMSPy model being solved by NVIDIA cuOpt:\n",
-        "1. Disable solver validation via `gp.set_options({\"SOLVER_VALIDATION\": 0})` as the solver is manually \"plugged into\" GAMSPy\n",
-        "2. Choose cuOpt as solver with `transport.solve(solver=\"cuopt\", ...)`\n",
-        "\n",
-        "Furthermore it sets two cuOpt solver options:\n",
-        "1. The [LP solution method](https://docs.nvidia.com/cuopt/user-guide/latest/lp-milp-settings.html#method) to PDLP\n",
-        "2. The [crossover flag](https://docs.nvidia.com/cuopt/user-guide/latest/lp-milp-settings.html#crossover) to false"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.251912Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.251772Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.453729Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.453525Z"
-        }
-      },
-      "source": [
-        "import sys\n",
-        "import gamspy as gp\n",
-        "\n",
-        "gp.set_options({\"SOLVER_VALIDATION\": 0})\n",
-        "transport.solve(solver=\"cuopt\", solver_options=dict(method=1, crossover=0), output=sys.stdout)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Retrieving Results\n",
-        "### Variable Values\n",
-        "The values of the variables in the solution can be retrieved using using ``<variable name>.records``. The level specifies the shipment quantities $x_{ij}$. Other variable attributes are the marginal values, lower and upper bounds, and the variable's scaling factor."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.454555Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.454455Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.458669Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.458521Z"
-        }
-      },
-      "source": [
-        "x.records.set_index([\"i\", \"j\"])"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Objective Value\n",
-        "The optimal objective function value can be accessed by `<model name>.objective_value`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "execution": {
-          "iopub.execute_input": "2025-07-17T10:21:41.459304Z",
-          "iopub.status.busy": "2025-07-17T10:21:41.459237Z",
-          "iopub.status.idle": "2025-07-17T10:21:41.460707Z",
-          "shell.execute_reply": "2025-07-17T10:21:41.460556Z"
-        }
-      },
-      "source": [
-        "transport.objective_value"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n",
-        "\n",
-        "SPDX-License-Identifier: Apache-2.0\n",
-        "\n",
-        "Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "you may not use this file except in compliance with the License.\n",
-        "You may obtain a copy of the License at\n",
-        "\n",
-        "http://www.apache.org/licenses/LICENSE-2.0\n",
-        "\n",
-        "Unless required by applicable law or agreed to in writing, software\n",
-        "distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "See the License for the specific language governing permissions and\n",
-        "limitations under the License."
-      ]
+    "vscode": {
+     "languageId": "shellscript"
     }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": ".venv",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.3"
-    }
+   },
+   "source": [
+    "# GAMSPy model example\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "This quick start guide is designed to provide you with a concise overview of GAMSPy and its key features. By the end of this guide, you'll have a solid understanding of how to create basic mathematical models using GAMSPy. For more advanced features, we recommend exploring our comprehensive [user guide](https://gamspy.readthedocs.io/en/latest/user/index.html) and the extensive [model library](https://gamspy.readthedocs.io/en/latest/user/model_library.html).\n",
+    "\n",
+    "While not mandatory, having a basic understanding of Python programming and familiarity with the [Pandas library](https://pandas.pydata.org/). will be helpful in following this tutorial.\n",
+    "\n",
+    "## A Transportation Problem\n",
+    "\n",
+    "In this guide, we'll delve into an example of the transportation problem. This classic scenario involves managing supplies from various plants to meet demands at multiple markets for a single commodity. Additionally, we have the unit costs associated with shipping the commodity from plants to markets. The fundamental economic question here is: \n",
+    "\n",
+    "> How can we optimize the shipment quantities between each plant and market to minimize the total transport cost?\n",
+    "\n",
+    "The problem's algebraic representation typically takes the following format:\n",
+    "\n",
+    "Indices (Sets):\n",
+    "\n",
+    "- $i$ = plants\n",
+    "- $j$ = markets\n",
+    "\n",
+    "Given Data (Parameters):\n",
+    "\n",
+    "- $a_i$ = supply of commodity at plant $i$ (in cases)\n",
+    "- $b_j$ = demand for commodity at market $j$ (in cases)\n",
+    "- $c_{ij}$ = cost per unit of shipment between plant $i$ and market $j$\n",
+    "\n",
+    "Decision Variables:\n",
+    "\n",
+    "- $x_{ij}$ = amount of commodity to ship from plant $i$ to market $j$ where $x_{ij} \\ge 0$ for all $i,j$\n",
+    "\n",
+    "Constraints:\n",
+    "\n",
+    "- Observe supply limit at plant $i$: $\\sum_j x_{ij} \\le a_i \\: \\forall i$\n",
+    "- Satisfy demand at market $j$: $\\sum_i x_{ij} \\ge b_j \\: \\forall j$\n",
+    "- Objective Function: Minimize $\\sum_i \\sum_j c_{ij} \\cdot x_{ij}$"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 4
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import subprocess\n",
+    "import html\n",
+    "from IPython.display import display, HTML\n",
+    "\n",
+    "def check_gpu():\n",
+    "    try:\n",
+    "        result = subprocess.run([\"nvidia-smi\"], capture_output=True, text=True, timeout=5)\n",
+    "        result.check_returncode()\n",
+    "        lines = result.stdout.splitlines()\n",
+    "        gpu_info = lines[2] if len(lines) > 2 else \"GPU detected\"\n",
+    "        gpu_info_escaped = html.escape(gpu_info)\n",
+    "        display(HTML(f\"\"\"\n",
+    "        <div style=\"border:2px solid #4CAF50;padding:10px;border-radius:10px;background:#e8f5e9;\">\n",
+    "            <h3>✅ GPU is enabled</h3>\n",
+    "            <pre>{gpu_info_escaped}</pre>\n",
+    "        </div>\n",
+    "        \"\"\"))\n",
+    "        return True\n",
+    "    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError, IndexError) as e:\n",
+    "        display(HTML(\"\"\"\n",
+    "        <div style=\"border:2px solid red;padding:15px;border-radius:10px;background:#ffeeee;\">\n",
+    "            <h3>⚠️ GPU not detected!</h3>\n",
+    "            <p>This notebook requires a <b>GPU runtime</b>.</p>\n",
+    "            \n",
+    "            <h4>If running in Google Colab:</h4>\n",
+    "            <ol>\n",
+    "              <li>Click on <b>Runtime → Change runtime type</b></li>\n",
+    "              <li>Set <b>Hardware accelerator</b> to <b>GPU</b></li>\n",
+    "              <li>Then click <b>Save</b> and <b>Runtime → Restart runtime</b>.</li>\n",
+    "            </ol>\n",
+    "            \n",
+    "            <h4>If running in Docker:</h4>\n",
+    "            <ol>\n",
+    "              <li>Ensure you have <b>NVIDIA Docker runtime</b> installed (<code>nvidia-docker2</code>)</li>\n",
+    "              <li>Run container with GPU support: <code>docker run --gpus all ...</code></li>\n",
+    "              <li>Or use: <code>docker run --runtime=nvidia ...</code> for older Docker versions</li>\n",
+    "              <li>Verify GPU access: <code>docker run --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi</code></li>\n",
+    "            </ol>\n",
+    "            \n",
+    "            <p><b>Additional resources:</b></p>\n",
+    "            <ul>\n",
+    "              <li><a href=\"https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html\" target=\"_blank\">NVIDIA Container Toolkit Installation Guide</a></li>\n",
+    "            </ul>\n",
+    "        </div>\n",
+    "        \"\"\"))\n",
+    "        return False\n",
+    "\n",
+    "check_gpu()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Enable this in case you are running this in google colab or such places where cuOpt is not yet installed\n",
+    "#!pip uninstall -y cuda-python cuda-bindings cuda-core\n",
+    "#!pip install --upgrade --extra-index-url=https://pypi.nvidia.com cuopt-cu12 nvidia-nvjitlink-cu12 rapids-logger==0.1.19\n",
+    "#!pip install --upgrade --extra-index-url=https://pypi.nvidia.com cuopt-cu13 nvidia-nvjitlink-cu13 rapids-logger==0.1.1"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Install other dependencies (if not already installed)\n",
+    "\n",
+    "!pip install -q gamspy\n",
+    "import subprocess\n",
+    "import sys\n",
+    "# Change the zip URL below depending on your target CUDA version and architecture (x86_64 or aarch64).\n",
+    "# See https://github.com/GAMS-dev/cuoptlink-builder/releases for available builds.\n",
+    "!wget -nc -nv -O cuopt-link-release.zip \"https://github.com/GAMS-dev/cuoptlink-builder/releases/download/v0.0.5e/cuopt-link-release-cu13-x86_64.zip\"\n",
+    "gams_base_path = subprocess.check_output([sys.executable, '-m', 'gamspy', 'show', 'base']).decode('utf-8').strip()\n",
+    "subprocess.run(f\"unzip -o cuopt-link-release.zip -d {gams_base_path}\", shell=True, check=True)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data\n",
+    "\n",
+    "Before we dive into the optimization process, let's handle our data using the [Pandas library](https://pandas.pydata.org/). We'll begin by organizing the necessary information, which we will subsequently feed into our optimization model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:40.915536Z",
+     "iopub.status.busy": "2025-07-17T10:21:40.915457Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.083438Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.083230Z"
+    }
+   },
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "capacities = pd.DataFrame(\n",
+    "    [[\"seattle\", 350], [\"san-diego\", 600]], columns=[\"city\", \"capacity\"]\n",
+    ").set_index(\"city\")\n",
+    "\n",
+    "capacities"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.084284Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.084168Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.086987Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.086797Z"
+    }
+   },
+   "source": [
+    "demands = pd.DataFrame(\n",
+    "    [[\"new-york\", 325], [\"chicago\", 300], [\"topeka\", 275]], columns=[\"city\", \"demand\"]\n",
+    ").set_index(\"city\")\n",
+    "\n",
+    "demands"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.087770Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.087633Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.091517Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.091358Z"
+    }
+   },
+   "source": [
+    "distances = pd.DataFrame(\n",
+    "    [\n",
+    "        [\"seattle\", \"new-york\", 2.5],\n",
+    "        [\"seattle\", \"chicago\", 1.7],\n",
+    "        [\"seattle\", \"topeka\", 1.8],\n",
+    "        [\"san-diego\", \"new-york\", 2.5],\n",
+    "        [\"san-diego\", \"chicago\", 1.8],\n",
+    "        [\"san-diego\", \"topeka\", 1.4],\n",
+    "    ],\n",
+    "    columns=[\"from\", \"to\", \"distance\"],\n",
+    ").set_index([\"from\", \"to\"])\n",
+    "\n",
+    "distances"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.092111Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.092042Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.093337Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.093174Z"
+    }
+   },
+   "source": [
+    "freight_cost = 90"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Symbol Declaration\n",
+    "\n",
+    "In line with our systematic breakdown of the transportation problem into sets, parameters, variables, and constraints, we will adopt a similar approach to define the problem as a GAMSPy `Model`. To do so, it is essential to import the `gamspy` library initially."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.093948Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.093881Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.163655Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.163440Z"
+    }
+   },
+   "source": [
+    "from gamspy import Container, Set, Parameter, Variable, Equation, Model, Sum, Sense"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Container\n",
+    "\n",
+    "Before we proceed further, let's create a `Container` to encapsulate all the relevant information for our GAMSPy ``Model``. This ``Container`` acts as a centralized hub, gathering essential data, sets, parameters, variables, and constraints, providing a clear structure for our optimization problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.164784Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.164605Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.172679Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.172515Z"
+    }
+   },
+   "source": [
+    "m = Container()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Sets\n",
+    "\n",
+    "Sets serve as the fundamental building blocks of a GAMSPy ``Model``, directly corresponding to the indices in the algebraic representations of models. In our transportation problem context, we have defined the following indices:\n",
+    "\n",
+    "- $i$ = plants\n",
+    "- $j$ = markets\n",
+    "\n",
+    "For detailed guidance on using sets, please refer to the [set section](https://gamspy.readthedocs.io/en/latest/user/basics/set.html) of our user guide.\n",
+    "\n",
+    "There a two ways to declare sets:\n",
+    "\n",
+    "1. Separate declaration and data assignment\n",
+    "2. Combine declaration and data assignment\n",
+    "\n",
+    "#### Separate declaration and data assignment\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.173454Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.173302Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.179619Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.179429Z"
+    }
+   },
+   "source": [
+    "i = Set(container=m, name=\"i\", description=\"plants\")\n",
+    "i.setRecords(capacities.index)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Combine declaration and data assignment\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.180411Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.180278Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.190480Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.190323Z"
+    },
+    "tags": []
+   },
+   "source": [
+    "j = Set(container=m, name=\"j\", description=\"markets\", records=demands.index)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The effect of using the above `Set` statements is that we declared two sets, namely $i$ and $j$. Additionally, we provided descriptions to elaborate on their meaning, enhancing the readability of our ``Model``. Lastly, we assigned members to the sets, establishing a clear connection between the abstract sets and their real-world counterparts.\n",
+    "\n",
+    "$i$ = {Seattle, San Diego}\n",
+    "\n",
+    "$j$ = {New York, Chicago, Topeka}\n",
+    "\n",
+    "To verify the content of a set, you can use `<set name>.records`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.191227Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.191108Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.193520Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.193371Z"
+    }
+   },
+   "source": [
+    "i.records"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.194209Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.194141Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.196323Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.196172Z"
+    }
+   },
+   "source": [
+    "j.records"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Parameters\n",
+    "\n",
+    "Declaring parameters involves using `Parameter`. Each parameter is assigned a name and a description.  Note that parameter $a_i$ is indexed by $i$. To accommodate these indices, we include the `domain` attribute, pointing to the corresponding set.\n",
+    "\n",
+    "It is worth mentioning that, similar to sets, you have the flexibility to either combine or separate the declaration and data assignment steps. For convenience, we will proceed by combining the declaration and data assignment.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.196997Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.196933Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.201694Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.201542Z"
+    }
+   },
+   "source": [
+    "a = Parameter(\n",
+    "    container=m, \n",
+    "    name=\"a\",\n",
+    "    domain=i,\n",
+    "    description=\"supply of commodity at plant i (in cases)\",\n",
+    "    records=capacities.reset_index(),\n",
+    ")\n",
+    "a.records"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.202335Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.202270Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.206850Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.206694Z"
+    }
+   },
+   "source": [
+    "b = Parameter(\n",
+    "    container=m,\n",
+    "    name=\"b\",\n",
+    "    domain=j,\n",
+    "    description=\"demand for commodity at market j (in cases)\",\n",
+    "    records=demands.reset_index(),\n",
+    ")\n",
+    "b.records"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.207532Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.207468Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.209778Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.209610Z"
+    }
+   },
+   "source": [
+    "c = Parameter(\n",
+    "    container=m,\n",
+    "    name=\"c\",\n",
+    "    domain=[i, j],\n",
+    "    description=\"cost per unit of shipment between plant i and market j\",\n",
+    ")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The cost per unit of shipment between plant $i$ and market $j$ is derived from the distance between $i$ and $j$ and can be calculated as follows:\n",
+    "\n",
+    "$c_{ij} = \\frac{90 \\cdot d_{ij}}{1000}$,\n",
+    "\n",
+    "where $d_{ij}$ denotes the distance between $i$ and $j$.\n",
+    "\n",
+    "We have two options to calculate $c_{ij}$ and assign the data to the GAMSPy parameter:\n",
+    "\n",
+    "1. Python assignment - calculation in Python, e.g., using Pandas and `<parameter name>.setRecords()`\n",
+    "2. GAMSPy assignment - calculation in GAMSPy\n",
+    "\n",
+    "#### Python Assignment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.210541Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.210390Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.213168Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.213001Z"
+    }
+   },
+   "source": [
+    "cost = freight_cost * distances / 1000\n",
+    "cost"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.213745Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.213681Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.218945Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.218784Z"
+    }
+   },
+   "source": [
+    "c.setRecords(cost.reset_index())\n",
+    "c.records"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### GAMSPy Assignment\n",
+    "\n",
+    "For the direct assignment we need to declare a new ``Parameter`` denoting the distances between $i$ and $j$.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.219662Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.219599Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.225144Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.224999Z"
+    }
+   },
+   "source": [
+    "d = Parameter(\n",
+    "    container=m,\n",
+    "    name=\"d\",\n",
+    "    domain=[i, j],\n",
+    "    description=\"distance between plant i and market j\",\n",
+    "    records=distances.reset_index(),\n",
+    ")\n",
+    "d.records"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.225778Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.225715Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.230168Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.229995Z"
+    }
+   },
+   "source": [
+    "c[i, j] = freight_cost * d[i, j] / 1000\n",
+    "c.records"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Further information on the usage of parameters can be found in our [parameter section](https://gamspy.readthedocs.io/en/latest/user/basics/parameter.html) of the user guide."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Variables\n",
+    "\n",
+    "GAMSPy variables are declared using `Variable`. Each ``Variable`` is assigned a name, a domain if necessary, a type, and, optionally, a description."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.230884Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.230819Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.233170Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.233016Z"
+    }
+   },
+   "source": [
+    "x = Variable(\n",
+    "    container=m,\n",
+    "    name=\"x\",\n",
+    "    domain=[i, j],\n",
+    "    type=\"Positive\",\n",
+    "    description=\"amount of commodity to ship from plant i to market j\",\n",
+    ")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This statement results in the declaration of a shipment variable for each (i,j) pair.\n",
+    "\n",
+    "More information on variables can be found in the [variable section](https://gamspy.readthedocs.io/en/latest/user/basics/variable.html) of our user guide."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Equations\n",
+    "A GAMSPy ``Equation`` must be declared and defined in two separate statements. The format of the declaration is the same as for other GAMSPy symbols. First comes the keyword, `Equation` in this case, followed by the name, domain and text. The transportation problem has two constraints:\n",
+    "\n",
+    "Supply: observe supply limit at plant $i$: $\\sum_j x_{ij} \\le a_i \\: \\forall i$\n",
+    "\n",
+    "Demand: satisfy demand at market $j$: $\\sum_i x_{ij} \\ge b_j \\: \\forall j$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.233875Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.233798Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.237181Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.237005Z"
+    }
+   },
+   "source": [
+    "supply = Equation(\n",
+    "    container=m, name=\"supply\", domain=i, description=\"observe supply limit at plant i\"\n",
+    ")\n",
+    "demand = Equation(\n",
+    "    container=m, name=\"demand\", domain=j, description=\"satisfy demand at market j\"\n",
+    ")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The components of an ``Equation`` definition are:\n",
+    "1. The Python variable of the ``Equation`` being defined\n",
+    "2. The domain (optional)\n",
+    "3. Domain restricting conditions (optional)\n",
+    "4. A `=` sign\n",
+    "5. Left hand side expression\n",
+    "6. Relational operator (`==`, `<=`, `>=`)\n",
+    "7. The right hand side expression.\n",
+    "\n",
+    "The ``Equation`` definition for the supply constraint of the transportation problem is implemented as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.237863Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.237785Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.240437Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.240285Z"
+    }
+   },
+   "source": [
+    "supply[i] = Sum(j, x[i, j]) <= a[i]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the same logic as above, we can define the demand equation as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.241111Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.241033Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.243421Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.243270Z"
+    }
+   },
+   "source": [
+    "demand[j] = Sum(i, x[i, j]) >= b[j]"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "More information on equations is given in the [equation section](https://gamspy.readthedocs.io/en/latest/user/basics/equation.html) of our user guide."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Objective\n",
+    "The objective function of a GAMSPy ``Model`` does not require a separate ``Equation`` declaration. You can assign the objective expression to a Python variable or use it directly in the ``Model()`` statement of the [next section](#model).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.244117Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.244038Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.245432Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.245247Z"
+    }
+   },
+   "source": [
+    "obj = Sum((i, j), c[i, j] * x[i, j])"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model\n",
+    "\n",
+    "A GAMSPy `Model()` consolidates constraints, an objective function, a sense (minimize, maximize, and feasibility), and a problem type. It also possesses a name and is associated with a ``Container``.\n",
+    "\n",
+    "To define our transportation problem as a GAMSPy ``Model``, we assign it to a Python variable, link it to our ``Container`` (populated with symbols and data), name it \"transport\", specify the equations, set the problem type as linear program (LP), specify the sense of the objective function (``Sense.MIN``), and point to the objective expression.\n",
+    "\n",
+    "GAMSPy allows two alternatives to assign equations to a `Model`:\n",
+    "1. Using a list of equations,\n",
+    "2. Retrieving _all_ equations by calling `m.getEquations()`.\n",
+    "\n",
+    "### Using a List of Equations\n",
+    "Using a list of equations is especially useful if you want to define multiple GAMSPy ``Model``s with a subset of the  equations in your ``Container``. For the transportation problem this can be done as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.246093Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.246032Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.248358Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.248217Z"
+    }
+   },
+   "source": [
+    "transport = Model(\n",
+    "    m,\n",
+    "    name=\"transport\",\n",
+    "    equations=[supply, demand],\n",
+    "    problem=\"LP\",\n",
+    "    sense=Sense.MIN,\n",
+    "    objective=obj,\n",
+    ")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Retrieving all Equations\n",
+    "Using `m.getEquations()` is especially convenient if you want to include all equations of your ``Container`` to be associated with your model. For the transportation problem this can be done as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.248970Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.248907Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.251180Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.251016Z"
+    }
+   },
+   "source": [
+    "transport_2 = Model(\n",
+    "    m,\n",
+    "    name=\"transport2\",\n",
+    "    equations=m.getEquations(),\n",
+    "    problem=\"LP\",\n",
+    "    sense=Sense.MIN,\n",
+    "    objective=obj,\n",
+    ")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "More information on the usage of a GAMSPy `Model` can be found in the [model section](https://gamspy.readthedocs.io/en/latest/user/basics/model.html) of our user guide."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Solve\n",
+    "\n",
+    "Upon defining the GAMSPy ``Model``, it's ready for being solved. The ``solve()`` statement triggers the generation of the specific model instance, creates suitable data structures for the solver, and invokes the solver. To view solver output in the console, the ``sys`` library can be used, passing the ``output=sys.stdout`` attribute to ``transport.solve()``.\n",
+    "\n",
+    "**Note**: The following cell contains the two most important pieces to get a GAMSPy model being solved by NVIDIA cuOpt:\n",
+    "1. Disable solver validation via `gp.set_options({\"SOLVER_VALIDATION\": 0})` as the solver is manually \"plugged into\" GAMSPy\n",
+    "2. Choose cuOpt as solver with `transport.solve(solver=\"cuopt\", ...)`\n",
+    "\n",
+    "Furthermore it sets two cuOpt solver options:\n",
+    "1. The [LP solution method](https://docs.nvidia.com/cuopt/user-guide/latest/lp-milp-settings.html#method) to PDLP\n",
+    "2. The [crossover flag](https://docs.nvidia.com/cuopt/user-guide/latest/lp-milp-settings.html#crossover) to false"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.251912Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.251772Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.453729Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.453525Z"
+    }
+   },
+   "source": [
+    "import sys\n",
+    "import gamspy as gp\n",
+    "\n",
+    "gp.set_options({\"SOLVER_VALIDATION\": 0})\n",
+    "transport.solve(solver=\"cuopt\", solver_options=dict(method=1, crossover=0), output=sys.stdout)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieving Results\n",
+    "### Variable Values\n",
+    "The values of the variables in the solution can be retrieved using using ``<variable name>.records``. The level specifies the shipment quantities $x_{ij}$. Other variable attributes are the marginal values, lower and upper bounds, and the variable's scaling factor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.454555Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.454455Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.458669Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.458521Z"
+    }
+   },
+   "source": [
+    "x.records.set_index([\"i\", \"j\"])"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Objective Value\n",
+    "The optimal objective function value can be accessed by `<model name>.objective_value`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-07-17T10:21:41.459304Z",
+     "iopub.status.busy": "2025-07-17T10:21:41.459237Z",
+     "iopub.status.idle": "2025-07-17T10:21:41.460707Z",
+     "shell.execute_reply": "2025-07-17T10:21:41.460556Z"
+    }
+   },
+   "source": [
+    "transport.objective_value"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n",
+    "\n",
+    "SPDX-License-Identifier: Apache-2.0\n",
+    "\n",
+    "Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "you may not use this file except in compliance with the License.\n",
+    "You may obtain a copy of the License at\n",
+    "\n",
+    "http://www.apache.org/licenses/LICENSE-2.0\n",
+    "\n",
+    "Unless required by applicable law or agreed to in writing, software\n",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "See the License for the specific language governing permissions and\n",
+    "limitations under the License."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
## Summary

- `GAMSPy_integration_example/transport_cuopt.ipynb` was failing in CI ([job 84396240545](https://github.com/NVIDIA/cuopt/actions/runs/28426561531/job/84396240545)) with `SyntaxError: unterminated string literal`
- Root cause: the introductory cell (`cell_type=code`) contains pure markdown prose. nbconvert executes it as Python and hits a `SyntaxError` on the apostrophe in `"you'll"` — Python sees an unterminated string literal
- Fix: change `cell_type` from `code` to `markdown` and remove the code-only fields (`outputs`, `execution_count`)

## Test plan

- [ ] `conda-notebook-tests` CI job passes for GAMSPy notebook

🤖 Generated with [Claude Code](https://claude.com/claude-code)