### PR TITLE
fix: replace data_model import with cuopt.linear_programming.DataModel

### DIFF
--- a/sample_lp_sever_notebooks/linear-programming-with-datamodel.ipynb
+++ b/sample_lp_sever_notebooks/linear-programming-with-datamodel.ipynb
@@ -213,7 +213,7 @@
     "import numpy as np\n",
     "from cuopt.linear_programming.io import toDict\n",
     "\n",
-    "from data_model import DataModel\n",
+    "from cuopt.linear_programming import DataModel\n",
     "from cuopt_sh_client import ThinClientSolverSettings\n",
     "\n",
     "problem_data = {}\n",

--- a/sample_lp_sever_notebooks/mixed-integer-linear-programming-with-datamodel.ipynb
+++ b/sample_lp_sever_notebooks/mixed-integer-linear-programming-with-datamodel.ipynb
@@ -214,7 +214,7 @@
     "import numpy as np\n",
     "from cuopt.linear_programming.io import toDict\n",
     "\n",
-    "from data_model import DataModel\n",
+    "from cuopt.linear_programming import DataModel\n",
     "from cuopt_sh_client import ThinClientSolverSettings\n",
     "\n",
     "problem_data = {}\n",


### PR DESCRIPTION
The standalone `data_model` cython binding was folded into the main cuopt wheel in NVIDIA/cuopt#1193. The replacement is `from cuopt.linear_programming import DataModel`.

Fixes notebook CI failure: `ModuleNotFoundError: No module named 'data_model'`

Tested locally in `nvidia/cuopt:26.6.0a-cuda13.2-py3.14` container — both notebooks pass.