### PR TITLE
Update README image tags to use Docker Hub latest-cu12/cu13 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,24 +34,26 @@ cd cuopt-examples
 For cuda-13:
 
 ```bash
-docker pull nvidia/cuopt:25.12.0a-cuda13.0-py3.13
+docker pull nvidia/cuopt:latest-cu13
+# To pin to a specific release: docker pull nvidia/cuopt:26.8.0-cu13
 ```
 
-For cuda-12
+For cuda-12:
 ```bash
-docker pull nvidia/cuopt:25.12.0a-cuda12.9-py3.13
+docker pull nvidia/cuopt:latest-cu12
+# To pin to a specific release: docker pull nvidia/cuopt:26.8.0-cu12
 ```
 
 3. Run the examples:
 
 For cuda-13:
 ```bash
-docker run -it --rm --gpus all --network=host -v $(pwd):/workspace -w /workspace nvidia/cuopt:25.12.0a-cuda13.0-py3.13 /bin/bash -c "pip install -r requirements.txt; jupyter-notebook"
+docker run -it --rm --gpus all --network=host -v $(pwd):/workspace -w /workspace nvidia/cuopt:latest-cu13 /bin/bash -c "pip install -r requirements.txt; jupyter-notebook"
 ```
 
 For cuda-12:
 ```bash
-docker run -it --rm --gpus all --network=host -v $(pwd):/workspace -w /workspace nvidia/cuopt:25.12.0a-cuda12.9-py3.13 /bin/bash -c "pip install -r requirements.txt; jupyter-notebook"
+docker run -it --rm --gpus all --network=host -v $(pwd):/workspace -w /workspace nvidia/cuopt:latest-cu12 /bin/bash -c "pip install -r requirements.txt; jupyter-notebook"
 ```
 
 4. Open your browser with the link provided in the terminal, and you can see the notebooks.

--- a/cuopt-agent/README.md
+++ b/cuopt-agent/README.md
@@ -51,7 +51,7 @@ The cuOpt Agent is a reference optimization assistant that translates natural-la
 
 - NVIDIA GPU with CUDA support
 - Docker and Docker Compose (with [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html))
-- Access to `nvcr.io/nvidia/cuopt/cuopt:26.2.0-cuda12.9-py3.13` base image ([NGC](https://catalog.ngc.nvidia.com/))
+- Access to `nvidia/cuopt:latest-cu12` base image ([Docker Hub](https://hub.docker.com/r/nvidia/cuopt)) or a pinned release such as `nvidia/cuopt:26.8.0-cu12`
 - NVIDIA API key from [build.nvidia.com](https://build.nvidia.com/)
 
 **Optional:**

--- a/cuopt_on_nemoclaw/README.md
+++ b/cuopt_on_nemoclaw/README.md
@@ -184,12 +184,15 @@ official cuOpt container — the sandbox expects them at ports 5000 (REST) and
 - NVIDIA driver + [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) on the host (`nvidia-ctk --version`).
 - Docker can see the GPU: `docker run --rm --gpus all nvidia/cuda:12.8.0-base-ubuntu24.04 nvidia-smi`.
 
-Pick an image tag that matches your CUDA + Python; the latest stable line is
-`nvidia/cuopt:latest-cuda13.0-py3.13` (Docker Hub, no auth needed). The same
-image is published on NGC at `nvcr.io/nvidia/cuopt/cuopt:<tag>`.
+Pick an image tag that matches your CUDA version; the latest stable lines are
+`nvidia/cuopt:latest-cu13` (CUDA 13) and `nvidia/cuopt:latest-cu12` (CUDA 12),
+available on Docker Hub with no auth required.
+To pin to a specific release, use a versioned tag such as `26.8.0-cu13`.
 
 ```bash
-export CUOPT_IMAGE=nvidia/cuopt:latest-cuda13.0-py3.13
+export CUOPT_IMAGE=nvidia/cuopt:latest-cu13
+# To pin to a specific release:
+# export CUOPT_IMAGE=nvidia/cuopt:26.8.0-cu13
 docker pull "$CUOPT_IMAGE"
 ```
 


### PR DESCRIPTION
## Summary

- Replace old pinned nightly tags (`nvidia/cuopt:25.12.0a-cuda*-py3.13`) with `nvidia/cuopt:latest-cu13` / `latest-cu12` so docs don't need updating on every release
- Replace NGC reference (`nvcr.io/nvidia/cuopt/cuopt:26.2.0-cuda12.9-py3.13`) in `cuopt-agent/README.md` with Docker Hub format for consistency
- Add pinned-release comments showing the specific `26.8.0-cu13` / `26.8.0-cu12` tags for users who want to pin to a version
- Tags verified against Docker Hub (`hub.docker.com/r/nvidia/cuopt`)

## Files changed

- `README.md` — quick-start docker pull/run commands
- `cuopt-agent/README.md` — prerequisites section
- `cuopt_on_nemoclaw/README.md` — starting the cuOpt server section

## Test plan

- [x] Confirm `docker pull nvidia/cuopt:latest-cu13` and `latest-cu12` resolve on Docker Hub
- [x] Confirm `docker pull nvidia/cuopt:26.8.0-cu13` and `26.8.0-cu12` resolve on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)